### PR TITLE
OPTIONS_SOURCE=both — Zerodha primary + Sensibull Greeks enrichment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -24,10 +24,14 @@ LIVE_OPTIONS_ONLY=0
 ENABLE_INTELLIGENCE=0
 ENABLE_NARRATOR=0
 
-# Options data source: "zerodha" (default) uses Zerodha WebSocket tick-by-tick feed;
-# "sensibull" uses the public Sensibull wsrelay (no auth required, ~10-30s snapshots).
-# Sensibull mode also enriches options_aggregate with atm_iv, atm_iv_percentile,
-# atm_ivp_type, max_pain_strike, and future_price.
+# Options data source:
+#   "zerodha"   — Zerodha WebSocket only. Tick-accurate OI, bid/ask depth, OHLC.
+#                 No Greeks or IV percentile.
+#   "sensibull" — Sensibull public WebSocket only. Greeks, IV percentile, max pain.
+#                 No real bid/ask depth. No auth required.
+#   "both"      — Zerodha is primary (ltp, OI, depth, engine trigger).
+#                 Sensibull enriches Greeks/IV on Zerodha-subscribed strikes only.
+#                 Best data quality; requires valid enctoken (auto-refreshed by auth service).
 OPTIONS_SOURCE=zerodha
 
 # Optional: override expiry per symbol when zerodha_ctx is not pre-populated.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The system runs in two primary modes, orchestrated from `intraday/intraday_monit
 |------|------|---------------|------|
 | **INTRADAY** | 9:15 AM – 3:30 PM | 5-min candles (yfinance) + live WebSocket ticks (Zerodha) | Every ~310 seconds |
 | **POSITIONAL** | After 4:00 PM (EOD) | Daily candles — 90-day daily for futures, 2-year daily for equity | Single run |
-| **LIVE OPTIONS** | 9:15 AM – 3:30 PM (opt-in) | Per WebSocket tick (~ms) for NIFTY/BANKNIFTY options | Continuous |
+| **LIVE OPTIONS** | 9:15 AM – 3:30 PM (opt-in) | Per WebSocket tick (~ms) for NIFTY/BANKNIFTY/SENSEX options | Continuous |
 
 Mode selection in production (`PRODUCTION=1`) is time-based. In dev mode, `DEV_INTRADAY=1` or `DEV_POSITIONAL=1` select manually.
 
@@ -42,7 +42,8 @@ intraday/intraday_monitor.py          ← Main entry point & orchestrator
                    ├── PCRAnalyser              (active)
                    ├── MaxPainAnalyser          (active)
                    ├── OIChainAnalyser          (active)
-                   └── PanicModeAnalyser        (active — MUST be last)
+                   ├── PanicModeAnalyser        (active — MUST be last before composite)
+                   └── OptionSellerCompositeAnalyser  (active — MUST be registered after PanicModeAnalyser)
 ```
 
 ---
@@ -70,7 +71,8 @@ intraday/intraday_monitor.py          ← Main entry point & orchestrator
 | **PCRAnalyser** | `analyser/PCRAnalyser.py` | PCR extreme zones (contrarian), PCR directional bias, PCR trend (5-day), PCR intraday trend, PCR reversal, positional PCR reversal |
 | **MaxPainAnalyser** | `analyser/MaxPainAnalyser.py` | Max pain deviation (moderate/strong), max pain trend (converging/diverging), max pain alignment with PCR |
 | **OIChainAnalyser** | `analyser/OIChainAnalyser.py` | OI support/resistance, OI buildup, OI wall (statistical outlier), OI shift, intraday OI trend, intraday S/R shift, OI capitulation (positional), OI wall migration (positional), positional OI trend, OI acceleration |
-| **PanicModeAnalyser** | `analyser/PanicModeAnalyser.py` | PANIC_MODE (≥4/6 conditions aligned), PANIC_EXHAUSTION (≥3/4 contrarian conditions) — reads all earlier analysers' output, **must be last** |
+| **PanicModeAnalyser** | `analyser/PanicModeAnalyser.py` | PANIC_MODE (≥4/6 conditions aligned), PANIC_EXHAUSTION (≥3/4 contrarian conditions) — reads all earlier analysers' output, **must precede OptionSellerCompositeAnalyser** |
+| **OptionSellerCompositeAnalyser** | `analyser/OptionSellerCompositeAnalyser.py` | Three high-probability option-seller setups — GAMMA_TRAP (kill-switch: close shorts, directional breach confirmed), RANGE_BOUND_SETUP (Iron Condor / Strangle candidate: range-trapped + overpriced vol), SKEW_FADE_SETUP (directional credit spread: panic exhaustion at OI wall + reversal candle). All bypass score gate via `PRIORITY_OVERRIDE`. **Must be registered last** |
 | **LiveOIAnalyser** | `analyser/LiveOIAnalyser.py` | Real-time: PCR crossover, PCR extreme, PCR sustained trend, OI wall breach |
 | **LiveStraddleAnalyser** | `analyser/LiveStraddleAnalyser.py` | Real-time: IV expanding/compressing, implied move boundary, IV skew reversal |
 
@@ -78,7 +80,7 @@ intraday/intraday_monitor.py          ← Main entry point & orchestrator
 
 ## Live Options Engine (opt-in)
 
-When `ENABLE_LIVE_OPTIONS=1`, the system subscribes to NIFTY and BANKNIFTY weekly option chains via Zerodha WebSocket. Zone-based subscription keeps token count manageable (94 tokens per index across 3 zones):
+When `ENABLE_LIVE_OPTIONS=1`, the system subscribes to NIFTY, BANKNIFTY, and SENSEX weekly option chains via Zerodha WebSocket. SENSEX uses the BFO segment (BSE derivatives); NIFTY and BANKNIFTY use NFO (NSE derivatives). Zone-based subscription keeps token count manageable (94 tokens per index across 3 zones):
 
 | Zone | Distance from ATM | WebSocket mode |
 |------|--------------------|----------------|
@@ -102,9 +104,11 @@ total_score = base_score + alignment_bonus
 
 - **Base score**: sum of `ANALYSIS_WEIGHTS[signal_type]` for all BULLISH or BEARISH signals
 - **Alignment bonus**: applied when signals span multiple categories (TECHNICAL + OPTIONS = 1.5× on base)
-- **Notification gate**: `total_score >= MIN_NOTIFICATION_SCORE (110)` to send Telegram alert
+- **Notification gate**: `total_score >= MIN_NOTIFICATION_SCORE (110)` for intraday; `total_score >= MIN_NOTIFICATION_SCORE_POSITIONAL (150)` for EOD positional
 - **Priority tiers**: LOW (≥35), MEDIUM (≥60), HIGH (≥90), CRITICAL (≥130)
 - **Confidence**: `dominant_side_score / total_score × 100`
+- **Winner-takes-all (composite setups)**: When `OptionSellerCompositeAnalyser` fires, it sets `PRIORITY_OVERRIDE` on `stock.analysis` and the orchestrator's `generate_analysis_message()` returns **only** the composite trade card (GAMMA_TRAP, RANGE_BOUND_SETUP, or SKEW_FADE_SETUP), suppressing all individual indicator output. This eliminates noise — the trader receives one clean, actionable card with no RSI/MACD/PCR clutter.
+- **Positional price-move filter**: Stocks with `|ltp_change_perc| < 0.75%` are skipped entirely in positional mode to avoid mechanical signals (BASIS_EXPANDING, PCR noise) on flat days.
 
 ---
 
@@ -137,6 +141,7 @@ When `ENABLE_NARRATOR=1` (requires `GEMINI_API_KEY`):
 | `NO_OF_INDEX` | Max indices to analyze (`-1` = all) |
 | `DEV_MAX_CYCLES` | Max intraday loop cycles in dev mode (`0` = unlimited) |
 | `DEV_LOOP_WAIT_TIME` | Seconds between dev cycles (`-1` = use production wait) |
+| `DEV_NOTIFY` | `1` = send Telegram alerts even in dev mode |
 
 ### Telegram
 
@@ -155,7 +160,8 @@ When `ENABLE_NARRATOR=1` (requires `GEMINI_API_KEY`):
 |----------|---------|
 | `ZERODHA_USER` | Zerodha user ID |
 | `ZERODHA_PASS` | Zerodha password |
-| `ZERODHA_ENC_TOKEN` | Enctoken for API auth (expires — refresh via `/enctoken` bot command) |
+| `ZERODHA_TOTP_SECRET` | Base-32 TOTP secret for automated 2FA login (`auth/auth_login.py`) |
+| `ZERODHA_ENC_TOKEN` | Enctoken for API auth (auto-refreshed by `auth/auth_login.py`; also updatable via `/enctoken` bot command) |
 
 ### Feature Flags
 
@@ -171,6 +177,30 @@ When `ENABLE_NARRATOR=1` (requires `GEMINI_API_KEY`):
 | `ENABLE_NARRATOR` | `0` | Enable LLM trade narratives (requires `GEMINI_API_KEY`) |
 | `OPTIONS_SOURCE` | `zerodha` | `zerodha` or `sensibull` for live option tick source |
 | `HEALTHCHECK_URL` | (empty) | Dead-man's switch ping URL (e.g., healthchecks.io) |
+
+---
+
+## Automated Zerodha Authentication
+
+`auth/auth_login.py` performs a fully automated TOTP-based Zerodha login and writes the fresh `ZERODHA_ENC_TOKEN` directly into `.env`, removing the need for manual token updates.
+
+Requires `ZERODHA_USER`, `ZERODHA_PASS`, and `ZERODHA_TOTP_SECRET` in `.env`.
+
+```bash
+python auth/auth_login.py   # generates enctoken and writes it to .env
+```
+
+In production the `stockanalysis-auth.service` systemd unit (see `scripts/system_config`) runs this automatically at boot, **before** the intraday monitor starts. The `stockanalysis.service` and `stockanalysis-positional.service` both `Require=` the auth service, so a failed login halts the analysis service instead of running with an expired token.
+
+`scripts/system_config` contains all four systemd unit files needed for a full EC2 deployment:
+
+| Unit | Trigger | Purpose |
+|------|---------|--------|
+| `stockanalysis-auth.service` | At boot | TOTP login — writes fresh enctoken to `.env` |
+| `stockanalysis.service` | Via timer | Intraday monitor during market hours |
+| `stockanalysis.timer` | Mon–Fri 03:30 UTC (9:00 AM IST) | Triggers intraday service |
+| `stockanalysis-positional.service` | Via timer | EOD positional analysis |
+| `stockanalysis-positional.timer` | Mon–Fri 14:30 UTC (8:00 PM IST) | Triggers positional service |
 
 ---
 
@@ -210,16 +240,54 @@ python intraday/intraday_monitor.py --index NIFTY
 ### Makefile targets
 
 ```bash
-make venv              # Create .venv/
-make install           # Install production dependencies
-make run-prod          # PRODUCTION=1 intraday monitor
-make run-dev           # PRODUCTION=0 intraday monitor (safe)
-make run-postmarket    # Post-market analysis pipeline
-make deploy            # git pull + restart service on EC2 via SSH
-make service-stop      # Start EC2 (if stopped) + stop service; exits early on holidays
-make test              # Full test suite
-make lint              # ruff check
-make logs-follow       # Follow logs/monitor.log live
+# Setup
+make venv                          # Create .venv/
+make install                       # Install production dependencies
+make install-dev                   # Install prod + dev/test tools
+make install-deploy                # Install deploy tools (boto3, paramiko)
+make env-check                     # Verify required .env variables are set
+
+# Run
+make run-prod                      # PRODUCTION=1 intraday monitor
+make run-dev                       # DEV_INTRADAY=1 intraday monitor
+make run-dev-positional            # DEV_POSITIONAL=1 EOD analysis
+make run-dev-stock-intraday STOCK=RELIANCE   # Single stock intraday
+make run-dev-stock-positional STOCK=RELIANCE # Single stock positional
+make run-dev-index-intraday INDEX=NIFTY      # Single index intraday
+make run-dev-index-positional INDEX=NIFTY    # Single index positional
+make run-premarket                 # Global cues + pre-open reports
+make run-postmarket                # Post-market analysis pipeline
+make deploy                        # git pull + restart service on EC2 via SSH
+make service-stop                  # Start EC2 (if stopped) + stop service; exits early on holidays
+make service-stop-force            # Same but bypasses holiday guard (dev use)
+
+# Test
+make test                          # Full test suite
+make test-fast                     # Stop on first failure (-x)
+make test-cov                      # With coverage report
+make test-module MODULE=premarket  # Tests for a specific module
+
+# Code quality
+make lint                          # ruff check
+make format                        # ruff format (auto-fix)
+make typecheck                     # pyright type check
+
+# Maintenance
+make update-derivatives            # Refresh final_derivatives_list.json
+make logs                          # Tail last 50 lines of monitor.log
+make logs-follow                   # Follow logs/monitor.log live
+make clean                         # Remove __pycache__, .pyc, pytest cache
+make clean-all                     # clean + remove .venv
+
+# Server (hacker@100.92.21.31)
+make server-ssh                    # Open interactive SSH session
+make server-logs                   # Tail last 50 lines on server
+make server-logs-follow            # Live-follow service log on server
+make server-status                 # Show stock_analysis.service status
+make server-restart                # Restart stock_analysis.service
+make server-pull                   # git pull on server repo
+make server-df                     # Disk usage on server
+make update-enctoken TOKEN=<tok>   # Update ZERODHA_ENC_TOKEN on server .env
 ```
 
 ---
@@ -228,7 +296,8 @@ make logs-follow       # Follow logs/monitor.log live
 
 ```
 StockAnalysis/
-├── analyser/          # All analyser classes (11 files)
+├── analyser/          # All analyser classes (12 files incl. OptionSellerCompositeAnalyser)
+├── auth/              # auth_login.py — automated TOTP-based Zerodha enctoken refresh
 ├── backtest/          # Backtesting framework + Optuna optimizer
 ├── common/            # Stock.py, shared.py, constants.py, scoring.py, token_registry.py
 ├── configs/           # custom_holidays.json, ml_config.yaml
@@ -242,7 +311,7 @@ StockAnalysis/
 ├── nse/               # NSE API wrappers + market calendar helpers
 ├── post_market_analysis/  # FII/DII, sector perf, F&O OI, index returns pipeline
 ├── premarket/         # Global cues, bonds, commodities, pre-open report
-├── scripts/           # deploy.py, service_stop.py (holiday-aware)
+├── scripts/           # deploy.py, service_stop.py (holiday-aware), system_config (systemd units)
 ├── sentiment/         # FinBERT news sentiment
 ├── tests/             # 951 tests across 41 files
 ├── zerodha/           # WebSocket lifecycle, TickStore, FuturesFetcher, LiveOptionsEngine
@@ -259,6 +328,9 @@ StockAnalysis/
 | `common/constants.py` | ANALYSIS_WEIGHTS, priority thresholds, env var names, category sets |
 | `common/shared.py` | AppContext singleton, Mode enum, global state |
 | `common/scoring.py` | Score calculation, alignment bonus, should_notify() |
+| `analyser/OptionSellerCompositeAnalyser.py` | Option-seller composite setups: GAMMA_TRAP, RANGE_BOUND_SETUP, SKEW_FADE_SETUP |
+| `auth/auth_login.py` | Automated TOTP Zerodha login — writes fresh enctoken to `.env` |
+| `scripts/system_config` | systemd unit files for EC2 deployment (auth + intraday + positional services + timers) |
 | `analyser/Analyser.py` | BaseAnalyzer (decorator framework) + AnalyserOrchestrator |
 | `zerodha/futures_fetcher.py` | FuturesFetcher — Kite historical futures data |
 | `fno/sensibull_fetcher.py` | SensibullFetcher — Sensibull API (insights, OI chain, IV chart, OI history) |

--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -859,6 +859,13 @@ ANALYSIS_WEIGHTS = {
     "PANIC_MODE":                   22,
     "PANIC_EXHAUSTION":             25,
 
+    # Option-seller composite setups (OptionSellerCompositeAnalyser)
+    # Weight = 0 intentionally: these bypass the score gate via PRIORITY_OVERRIDE.
+    # A non-zero weight would artificially inflate scores alongside regular signals.
+    "GAMMA_TRAP":                    0,   # Kill-switch — close short positions, directional breach
+    "RANGE_BOUND_SETUP":             0,   # Iron Condor / Strangle — range-trapped + overpriced vol
+    "SKEW_FADE_SETUP":               0,   # Directional credit spread — fade panic at OI wall
+
     # Price levels
     "52-week-high":                  8,
     "52-week-low":                   8,
@@ -871,7 +878,10 @@ ANALYSIS_WEIGHTS = {
 ### Scoring constants
 
 ```python
-MIN_NOTIFICATION_SCORE = 110    # Minimum score to send Telegram alert
+MIN_NOTIFICATION_SCORE = 110              # Minimum score to send intraday Telegram alert
+MIN_NOTIFICATION_SCORE_POSITIONAL = 150   # EOD positional mode (higher bar: 50+ stocks;
+                                          # near-expiry week inflates scores mechanically;
+                                          # 150 requires genuine cross-category alignment)
 
 NOTIFICATION_PRIORITY = {
     "LOW":      35,    # 3–4 aligned signals
@@ -893,6 +903,11 @@ NEUTRAL_EXCLUDE_FROM_SCORE = {
     "OI_SUPPORT_RESISTANCE", # When neutral — informational S/R
     "OI_SR_SHIFT",           # When neutral — range squeeze/expand is informational
     "FUTURE_ROLLOVER",       # Context only — not directional
+    # Composite option-seller setups — weight=0 above, also excluded here for safety
+    "RANGE_BOUND_SETUP",
+    "SKEW_FADE_SETUP",
+    "GAMMA_TRAP",
+    "GAMMA_TRAP_ACTIVE",     # Boolean suppression flag written by Gamma Trap
 }
 ```
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,6 +1,6 @@
 # StockAnalysis - Comprehensive Design Document
 
-> **Last Updated**: May 2026 (All 9 analysers now active; FuturesAnalyser new positional/intraday methods + fixes; Sensibull OI history fetch; PCRAnalyser positional PCR reversal + intraday trend; OIChainAnalyser extended positional methods; MIN_NOTIFICATION_SCORE raised to 110; updated ANALYSIS_WEIGHTS; `options_source` + `sensibull_feed` in AppContext; `oi_history` in sensibull_ctx)
+> **Last Updated**: May 2026 (OptionSellerCompositeAnalyser added: GAMMA_TRAP, RANGE_BOUND_SETUP, SKEW_FADE_SETUP with PRIORITY_OVERRIDE / winner-takes-all message dispatch; SENSEX added to live options indices; auth/auth_login.py for automated TOTP enctoken refresh; scripts/system_config systemd units; MIN_NOTIFICATION_SCORE_POSITIONAL=150; positional price-move filter 0.75%)
 > **Purpose**: Complete architectural reference for the Indian Stock Market Analysis System targeting NSE (National Stock Exchange) equities. This document captures the entire codebase: architecture, data flows, module interactions, signal processing, scoring, notifications, and deployment details.
 
 ---
@@ -40,8 +40,8 @@
 An automated stock market analysis system for the Indian market (NSE) that:
 - Monitors stocks in **real-time during market hours** (intraday mode, 5-min intervals, 9:15 AM - 3:30 PM)
 - Performs **end-of-day positional analysis** (daily data, ~2 years history)
-- Tracks **live NIFTY/BANKNIFTY options per tick** via Zerodha WebSocket (zone-based subscription)
-- Runs **8 specialized analyzers** across technical, volume, candlestick, options, futures, IV, PCR, max pain, and OI chain domains
+- Tracks **live NIFTY, BANKNIFTY, and SENSEX options per tick** via Zerodha WebSocket (zone-based subscription; SENSEX uses BFO segment)
+- Runs **9 specialized analyzers** across technical, volume, candlestick, options, futures, IV, PCR, max pain, and OI chain domains, plus **1 composite analyser** (`OptionSellerCompositeAnalyser`) for high-probability option-seller setups
 - Runs **2 live options analyzers** (LiveOIAnalyser, LiveStraddleAnalyser) on real-time option ticks
 - Scores signals with a **weighted scoring engine** and sends alerts to **Telegram channels**
 - Generates **pre-market** and **post-market** summary reports
@@ -86,7 +86,10 @@ StockAnalysis/
 |   |-- LiveOptionsHistory.py        # In-memory per-symbol time-series (375 snapshots/day)
 |   |-- LiveAlertFormatter.py        # HTML builder for real-time Telegram alerts (F singleton)
 |   |-- MessageFormatter.py          # Registry-based formatter for batch analysis alerts
-|   |-- PanicModeAnalyser.py         # Composite analyser — panic detection & exhaustion (9th, must be last)
+|   |-- PanicModeAnalyser.py         # Composite analyser — panic detection & exhaustion (9th, must precede OptionSellerCompositeAnalyser)
+|   |-- OptionSellerCompositeAnalyser.py  # Option-seller composite setups (10th, MUST be last)
+|                                    # Emits GAMMA_TRAP / RANGE_BOUND_SETUP / SKEW_FADE_SETUP
+|                                    # Sets PRIORITY_OVERRIDE; bypasses score gate via winner-takes-all dispatch
 |
 |-- intelligence/
 |   |-- signal.py                    # Signal dataclass, Direction, Layer, SignalStrength enums
@@ -155,12 +158,23 @@ StockAnalysis/
 |   |-- sensibull_fetcher.py         # SensibullFetcher — Sensibull API fetcher (extracted from Stock)
 |   |-- OptionWriteStandardDeviation.py  # Legacy standard deviation writer
 |
+|-- auth/
+|   |-- auth_login.py               # Automated TOTP Zerodha login — writes fresh enctoken to .env
+|                                    # Requires ZERODHA_USER, ZERODHA_PASS, ZERODHA_TOTP_SECRET
+|                                    # Used by stockanalysis-auth.service on EC2
+|
 |-- ml_pipeline/                     # ML prediction pipeline (XGBoost, LightGBM, RF, Ensemble)
 |-- scripts/
 |   |-- deploy.py                    # SSH deploy: git pull + restart service on EC2
 |   |-- service_stop.py              # Start EC2 (if stopped) + stop stock_analysis.service
 |                                    # Holiday guard: exits early on non-trading days unless --force
 |                                    # SSH retry-poll replaces fixed 15s sleep
+|   |-- system_config               # systemd unit files for EC2 deployment:
+|                                    #   stockanalysis-auth.service  (TOTP login, Type=oneshot)
+|                                    #   stockanalysis.service        (intraday monitor)
+|                                    #   stockanalysis.timer          (Mon-Fri 03:30 UTC / 9:00 AM IST)
+|                                    #   stockanalysis-positional.service  (EOD analysis)
+|                                    #   stockanalysis-positional.timer    (Mon-Fri 14:30 UTC / 8:00 PM IST)
 |-- configs/                         # Configuration files
 |-- data/                            # Stock lists (final_derivatives_list.json, etc.)
 |-- docs/                            # Documentation
@@ -660,12 +674,28 @@ FUTURES_ANALYSES = {
 ```python
 def should_notify(score_result):
     return (
-        score_result.total_score >= MIN_NOTIFICATION_SCORE  # 110
+        score_result.total_score >= MIN_NOTIFICATION_SCORE  # 110 intraday
         and score_result.confidence_pct >= 65               # 65% alignment gate
     )
+# Positional mode uses MIN_NOTIFICATION_SCORE_POSITIONAL = 150
+# (EOD runs on 50+ stocks; near-expiry week inflates scores mechanically;
+#  150 requires genuine cross-category alignment: futures + options + technical)
 ```
 
-> `MIN_NOTIFICATION_SCORE` was raised from 75 to 110 to reduce noise after the analyser pool was expanded (Supertrend, RSI Divergence, Stochastic, OBV, Pivot Points, enhanced candlestick pattern weights). 110 sits between HIGH (90) and CRITICAL (130) thresholds.
+#### Composite Setup Override (Winner-Takes-All)
+
+`OptionSellerCompositeAnalyser` runs last and cross-reads `stock.analysis` populated by all 9 preceding analysers. When a composite setup fires it:
+
+1. Writes `stock.analysis["NEUTRAL"]["GAMMA_TRAP"]` / `RANGE_BOUND_SETUP` / `SKEW_FADE_SETUP` namedtuple.
+2. Sets `stock.analysis["PRIORITY_OVERRIDE"] = NotificationPriority.CRITICAL/HIGH` — **score gate is bypassed**.
+3. `generate_analysis_message()` detects `PRIORITY_OVERRIDE` and returns **only** the composite trade card; all individual RSI/MACD/PCR/etc. cards are suppressed.
+
+Priority of composite keys (highest urgency rendered first):
+- `GAMMA_TRAP` → CRITICAL (kill-switch: close short positions, directional breach)
+- `SKEW_FADE_SETUP` → HIGH (directional credit spread: fade a panic at an OI wall)
+- `RANGE_BOUND_SETUP` → HIGH (Iron Condor / Strangle: range-trapped + overpriced vol)
+
+Weights in `ANALYSIS_WEIGHTS` for all three are intentionally `0` so they never inflate batch scores.
 
 ### `common/constants.py` - ANALYSIS_WEIGHTS
 
@@ -685,6 +715,8 @@ ANALYSIS_WEIGHTS = {
     "OI_ACCELERATION": 17, "OI_CAPITULATION": 16, "OI_POSITIONAL_TREND": 16,
     # Panic composite
     "PANIC_MODE": 22, "PANIC_EXHAUSTION": 25,
+    # Composite option-seller setups — weight=0: bypass score gate via PRIORITY_OVERRIDE
+    "GAMMA_TRAP": 0, "RANGE_BOUND_SETUP": 0, "SKEW_FADE_SETUP": 0,
 }
 
 NEUTRAL_EXCLUDE_FROM_SCORE = {
@@ -693,9 +725,14 @@ NEUTRAL_EXCLUDE_FROM_SCORE = {
     "OI_SUPPORT_RESISTANCE", # Informational S/R
     "OI_SR_SHIFT",           # Informational range
     "FUTURE_ROLLOVER",       # Context only
+    "RANGE_BOUND_SETUP",     # Composite — score bypassed via PRIORITY_OVERRIDE
+    "SKEW_FADE_SETUP",
+    "GAMMA_TRAP",
+    "GAMMA_TRAP_ACTIVE",     # Boolean suppression flag set by Gamma Trap
 }
 
-MIN_NOTIFICATION_SCORE = 110   # Raised from 75 — expanded analyser pool
+MIN_NOTIFICATION_SCORE = 110              # intraday default
+MIN_NOTIFICATION_SCORE_POSITIONAL = 150   # EOD positional (higher bar for 50+ stock run)
 ```
 
 ---
@@ -708,7 +745,7 @@ This is the production entry point that orchestrates the entire system.
 
 #### Registered Analyzers (current state)
 
-All 9 analysers are active. Registration order matters — `PanicModeAnalyser` must always be last because it reads `stock.analysis` populated by all preceding analysers.
+All 10 analysers are active. Registration order matters — `PanicModeAnalyser` must run before `OptionSellerCompositeAnalyser` because the composite analyser reads `PANIC_EXHAUSTION` from `stock.analysis`.
 
 ```python
 orchestrator.register(VolumeAnalyser())
@@ -719,7 +756,8 @@ orchestrator.register(FuturesAnalyser())
 orchestrator.register(PCRAnalyser())
 orchestrator.register(MaxPainAnalyser())
 orchestrator.register(OIChainAnalyser())
-orchestrator.register(PanicModeAnalyser())    # MUST be last — reads stock.analysis
+orchestrator.register(PanicModeAnalyser())                  # 9th — reads all preceding
+orchestrator.register(OptionSellerCompositeAnalyser())      # 10th — MUST be last
 ```
 
 | Order | Analyser | Signal categories | Mode |
@@ -732,7 +770,8 @@ orchestrator.register(PanicModeAnalyser())    # MUST be last — reads stock.ana
 | 6 | PCRAnalyser | PCR_EXTREME, PCR_BIAS, PCR_TREND, PCR_INTRADAY_TREND, PCR_REVERSAL, PCR_POS_REVERSAL, PCR_DIVERGENCE | both |
 | 7 | MaxPainAnalyser | MAX_PAIN, MAX_PAIN_TREND, MAX_PAIN_ALIGNMENT | both |
 | 8 | OIChainAnalyser | OI_SUPPORT_RESISTANCE, OI_BUILDUP, OI_WALL, OI_SHIFT, OI_INTRADAY_TREND, OI_SR_SHIFT, OI_CAPITULATION, OI_WALL_MIGRATION, OI_POSITIONAL_TREND, OI_ACCELERATION | both |
-| 9 | PanicModeAnalyser | PANIC_MODE, PANIC_EXHAUSTION | both — **must be last** |
+| 9 | PanicModeAnalyser | PANIC_MODE, PANIC_EXHAUSTION | both — reads all 8 above |
+| 10 | OptionSellerCompositeAnalyser | GAMMA_TRAP, RANGE_BOUND_SETUP, SKEW_FADE_SETUP | both — reads all 9 above; sets PRIORITY_OVERRIDE |
 
 #### Production Daily Timeline
 

--- a/fno/sensibull_adapter.py
+++ b/fno/sensibull_adapter.py
@@ -17,6 +17,12 @@ options_live[strike][CE/PE]:
 
 options_aggregate (Sensibull-only enrichment, patched after recompute):
   atm_iv, atm_iv_percentile, atm_ivp_type, max_pain_strike, future_price
+
+enrichment_only mode (OPTIONS_SOURCE=both):
+  Only Greeks/IV fields are written to options_live (via merge=True in
+  TickStore — silently skips far-OTM strikes not subscribed by Zerodha).
+  options_aggregate Sensibull fields are always patched.
+  on_aggregate_updated is NOT called (Zerodha is the authoritative trigger).
 """
 from __future__ import annotations
 
@@ -52,14 +58,23 @@ class SensibullAdapter:
         index_stock: "Stock",
         data: dict,
         live_options_engine: "LiveOptionsEngine",
+        enrichment_only: bool = False,
     ) -> None:
         """
         Process one Sensibull chain snapshot.
 
-        1. Update ``options_live`` for every strike/side.
-        2. Call ``recompute_options_aggregate`` (same as Zerodha path).
-        3. Patch Sensibull-only enrichment fields into ``options_aggregate``.
-        4. Call ``live_options_engine.on_aggregate_updated``.
+        Normal mode (enrichment_only=False):
+          1. Update ``options_live`` for every strike/side (full tick).
+          2. Call ``recompute_options_aggregate``.
+          3. Patch Sensibull-only enrichment fields into ``options_aggregate``.
+          4. Call ``live_options_engine.on_aggregate_updated``.
+
+        Enrichment-only mode (enrichment_only=True, OPTIONS_SOURCE=both):
+          1. Write only Greeks/IV fields to existing strikes (merge=True —
+             skips far-OTM strikes not yet written by Zerodha).
+          2. Patch Sensibull-only aggregate fields (atm_iv, ivp, max_pain…).
+          3. Does NOT call recompute_options_aggregate or on_aggregate_updated —
+             Zerodha is the authoritative tick source and engine trigger.
         """
         symbol = index_stock.stock_symbol
         chain: dict = data.get("chain", {})
@@ -123,21 +138,34 @@ class SensibullAdapter:
 
                 delta = call_delta if internal_side == "CE" else (call_delta - 1.0)
 
-                tick = {
-                    "last_price":           leg.get("last_price", 0),
-                    "oi":                   current_oi,
-                    "volume_traded":        leg.get("volume", 0),
-                    "total_buy_quantity":   leg.get("best_buy_price", 0),
-                    "total_sell_quantity":  leg.get("best_sell_price", 0),
-                    # greeks — per-strike from Sensibull
-                    "delta":    delta,
-                    "gamma":    gamma,
-                    "theta":    theta,
-                    "vega":     vega,
-                    "iv":       strike_iv_val,
-                    "iv_change": iv_change,
-                }
-                index_stock.update_option_tick(strike, internal_side, tick)
+                if enrichment_only:
+                    # Only write Greeks/IV — never touch ltp/oi/volume/buy_qty.
+                    # merge=True silently skips strikes not yet in options_live
+                    # (i.e. far-OTM strikes outside Zerodha's subscription zone).
+                    greek_tick = {
+                        "delta":     delta,
+                        "gamma":     gamma,
+                        "theta":     theta,
+                        "vega":      vega,
+                        "iv":        strike_iv_val,
+                        "iv_change": iv_change,
+                    }
+                    index_stock.update_option_tick(strike, internal_side, greek_tick, merge=True)
+                else:
+                    tick = {
+                        "last_price":           leg.get("last_price", 0),
+                        "oi":                   current_oi,
+                        "volume_traded":        leg.get("volume", 0),
+                        "total_buy_quantity":   leg.get("best_buy_price", 0),
+                        "total_sell_quantity":  leg.get("best_sell_price", 0),
+                        "delta":    delta,
+                        "gamma":    gamma,
+                        "theta":    theta,
+                        "vega":     vega,
+                        "iv":       strike_iv_val,
+                        "iv_change": iv_change,
+                    }
+                    index_stock.update_option_tick(strike, internal_side, tick)
 
             # Patch prev_oi using the snapshot taken before cache update.
             # TickStore.update_option_tick sets prev_oi = old entry["oi"] which
@@ -147,9 +175,12 @@ class SensibullAdapter:
             _patch_prev_oi(index_stock, strike, prev_oi_snapshot)
 
         # ── 2. Recompute aggregate (PCR, ATM strike, straddle, OI walls) ──────
-        index_stock.recompute_options_aggregate(spot if spot > 0 else None)
+        # Skipped in enrichment_only mode — Zerodha owns the aggregate trigger.
+        if not enrichment_only:
+            index_stock.recompute_options_aggregate(spot if spot > 0 else None)
 
         # ── 3. Patch Sensibull-only enrichment fields ─────────────────────────
+        # Always patched regardless of mode — Zerodha never writes these fields.
         agg = index_stock._tick_store.options_aggregate
         agg["atm_iv"]            = data.get("atm_iv", 0.0) or 0.0
         agg["atm_iv_percentile"] = data.get("atm_iv_percentile", 0.0) or 0.0
@@ -188,13 +219,15 @@ class SensibullAdapter:
                     agg["iv_skew"] = (pe_iv - ce_iv) * 100
 
         # ── 4. Notify the live options engine ─────────────────────────────────
-        if live_options_engine:
+        # Skipped in enrichment_only mode — Zerodha ticks are the authoritative
+        # engine trigger; Sensibull is a passive enrichment source only.
+        if live_options_engine and not enrichment_only:
             live_options_engine.on_aggregate_updated(index_stock, spot if spot > 0 else 0)
 
         logger.debug(
-            f"[SensibullAdapter] {symbol} updated — "
+            f"[SensibullAdapter] {symbol} {'enriched' if enrichment_only else 'updated'} — "
             f"strikes={len(chain)}, spot={spot}, "
-            f"pcr={agg.get('live_pcr', 0):.3f}, atm_iv={agg.get('atm_iv', 0):.3f}"
+            f"atm_iv={agg.get('atm_iv', 0):.3f}, ivp={agg.get('atm_iv_percentile', 0):.1f}"
         )
 
 

--- a/intraday/intraday_monitor.py
+++ b/intraday/intraday_monitor.py
@@ -1297,7 +1297,7 @@ def _get_nearest_expiry_str(index_stock) -> str | None:
     return None
 
 
-def _start_sensibull_feed(live_options_engine) -> None:
+def _start_sensibull_feed(live_options_engine, enrichment_only: bool = False) -> None:
     """
     Create one SensibullFeed per supported symbol and start them.
     The underlying token is read directly from index_token_obj_dict — the dict
@@ -1305,6 +1305,12 @@ def _start_sensibull_feed(live_options_engine) -> None:
     underlying identifier. No separate token mapping is needed.
     Expiry is resolved from the zerodha_ctx already populated at startup.
     Feeds are stored in ``shared.app_ctx.sensibull_feed``.
+
+    Args:
+        enrichment_only: When True (OPTIONS_SOURCE=both), Sensibull only writes
+                         Greeks/IV fields to existing Zerodha-subscribed strikes
+                         and does NOT trigger on_aggregate_updated. Zerodha is
+                         the authoritative tick source and engine trigger.
     """
     from fno.sensibull_feed import SensibullFeed
     from fno.sensibull_adapter import SensibullAdapter
@@ -1336,7 +1342,8 @@ def _start_sensibull_feed(live_options_engine) -> None:
         def make_callback(stock):
             def _on_snapshot(token: int, data: dict) -> None:
                 try:
-                    adapter.apply(stock, data, live_options_engine)
+                    adapter.apply(stock, data, live_options_engine,
+                                  enrichment_only=enrichment_only)
                 except Exception as exc:
                     logger.error(f"[Sensibull] snapshot error for {stock.stock_symbol}: {exc}")
             return _on_snapshot
@@ -1345,14 +1352,15 @@ def _start_sensibull_feed(live_options_engine) -> None:
         feed.start()
         feeds.append(feed)
         started_symbols.append(symbol)
-        logger.info(f"[Sensibull] feed started for {symbol} (underlying_token={underlying_token}, expiry={expiry})")
+        logger.info(f"[Sensibull] feed started for {symbol} (underlying_token={underlying_token}, expiry={expiry}, enrichment_only={enrichment_only})")
 
     if feeds:
         shared.app_ctx.sensibull_feed = feeds
+        mode_label = "Enrichment" if enrichment_only else "Primary"
         TELEGRAM_NOTIFICATIONS.send_live_options_notification(
-            f"📡 <b>Sensibull Live Feed Started</b> — {', '.join(started_symbols)}"
+            f"📡 <b>Sensibull Live Feed Started [{mode_label}]</b> — {', '.join(started_symbols)}"
         )
-        logger.info(f"[Sensibull] {len(feeds)} feed(s) running: {started_symbols}")
+        logger.info(f"[Sensibull] {len(feeds)} feed(s) running [{mode_label}]: {started_symbols}")
     else:
         logger.error("[Sensibull] no feeds started — check symbol/expiry configuration")
 
@@ -1380,8 +1388,9 @@ def live_options_analysis():
                 logger.info("Live options WebSocket connected")
                 from time import sleep as _sleep
                 _sleep(3)   # wait for first index ticks
-                if shared.app_ctx.options_source == "sensibull":
-                    _start_sensibull_feed(tm.live_options_engine)
+                if shared.app_ctx.options_source in ("sensibull", "both"):
+                    _enrichment_only = (shared.app_ctx.options_source == "both")
+                    _start_sensibull_feed(tm.live_options_engine, enrichment_only=_enrichment_only)
                 else:
                     from notification.bot_listener import _subscribe_registered_options
                     _subscribe_registered_options(tm)
@@ -1419,13 +1428,15 @@ def intraday_analysis(loop = True, loop_wait_time = 30, max_cycles = 0):
     # Start Sensibull live option chain feed independently of Zerodha WS.
     # Sensibull is a public WebSocket — no enctoken required.
     # Only start once (guard: sensibull_feed is None until first start).
+    _options_source = shared.app_ctx.options_source
     if (ENABLE_LIVE_OPTIONS
-            and shared.app_ctx.options_source == "sensibull"
+            and _options_source in ("sensibull", "both")
             and not shared.app_ctx.sensibull_feed):
         tm = shared.app_ctx.zd_ticker_manager
         if tm and tm.live_options_engine:
-            logger.info("[intraday] OPTIONS_SOURCE=sensibull — starting Sensibull feed")
-            _start_sensibull_feed(tm.live_options_engine)
+            _enrichment_only = (_options_source == "both")
+            logger.info(f"[intraday] OPTIONS_SOURCE={_options_source} — starting Sensibull feed (enrichment_only={_enrichment_only})")
+            _start_sensibull_feed(tm.live_options_engine, enrichment_only=_enrichment_only)
         else:
             logger.warning("[intraday] Cannot start Sensibull feed — LiveOptionsEngine not initialised")
 

--- a/zerodha/tick_store.py
+++ b/zerodha/tick_store.py
@@ -109,9 +109,25 @@ class TickStore:
     # Options ticks
     # ------------------------------------------------------------------
 
-    def update_option_tick(self, strike: float, option_type: str, tick: dict) -> None:
-        """Update live option data from a WebSocket tick."""
+    def update_option_tick(self, strike: float, option_type: str, tick: dict, merge: bool = False) -> None:
+        """Update live option data from a WebSocket tick.
+
+        Args:
+            merge: When True (enrichment-only mode), only writes keys present in
+                   ``tick`` without touching existing fields like ltp/oi/volume.
+                   The strike must already exist in options_live — if not, the
+                   update is silently skipped (Zerodha is the authoritative creator).
+                   Used by Sensibull in OPTIONS_SOURCE=both mode.
+        """
         with self._lock:
+            if merge:
+                # Enrichment-only: only update existing strikes (Zerodha-subscribed)
+                existing = self.options_live.get(strike, {}).get(option_type)
+                if existing is None:
+                    return
+                existing.update(tick)
+                return
+
             if strike not in self.options_live:
                 self.options_live[strike] = {}
 


### PR DESCRIPTION
Summary
Previously OPTIONS_SOURCE was binary: either zerodha (tick-accurate OI, no Greeks) or sensibull (Greeks + IV, no real depth). This PR adds a third mode — OPTIONS_SOURCE=both — that runs them simultaneously with clear ownership rules:

Field	Owner in both mode
ltp, oi, volume, bid/ask depth	Zerodha (primary, tick-accurate)
delta, gamma, theta, vega, iv, iv_change	Sensibull (passive enrichment)
atm_iv, atm_iv_percentile, atm_ivp_type, max_pain_strike, future_price	Sensibull (always patched into aggregate)
recompute_options_aggregate trigger	Zerodha only
on_aggregate_updated engine trigger	Zerodha only
Files Changed — 7 files, 258 insertions(+), 68 deletions(−)
tick_store.py (+20)
update_option_tick() gains a merge: bool = False parameter.
When merge=True: writes only the keys present in the incoming tick dict without touching existing fields (ltp, oi, volume). If the strike doesn't exist yet (Zerodha hasn't subscribed it), the call is silently skipped — Zerodha is the authoritative creator of entries in options_live.
sensibull_adapter.py (+79)
apply() gains enrichment_only: bool = False.
Normal mode (unchanged): full tick, recompute aggregate, trigger engine.
Enrichment-only mode (OPTIONS_SOURCE=both):
Only writes {delta, gamma, theta, vega, iv, iv_change} per strike via merge=True.
Skips far-OTM strikes not in Zerodha's subscription zone.
Does not call recompute_options_aggregate or on_aggregate_updated — Zerodha owns those.
Always patches Sensibull-only aggregate fields (atm_iv, ivp, max_pain, future_price) regardless of mode.
Debug log updated: shows enriched vs updated label and ivp instead of pcr.
intraday_monitor.py (+31)
_start_sensibull_feed() accepts and forwards the enrichment_only flag to the adapter callback closure.
Both intraday_analysis() and live_options_analysis() now check options_source in ("sensibull", "both") (previously == "sensibull").
enrichment_only is derived from options_source == "both" and passed through.
Telegram startup notification and log messages now include a [Primary] / [Enrichment] mode label.
.env.template (+12)
OPTIONS_SOURCE comment expanded to a three-way comparison table documenting trade-offs for each value (zerodha / sensibull / both).
Notes that both requires a valid enctoken (auto-refreshed by the auth service).
Docs (+184)
README.md, DESIGN.md, DATA_SCHEMA.md — updated in the same commit as part of the documentation refresh covering OptionSellerCompositeAnalyser, SENSEX live options, auth module, scoring constants, and Makefile targets.
Motivation
Zerodha alone: tick-accurate OI and depth, but no Greeks — analysers like IVAnalyser.analyse_iv_vs_hv get no live IV; options_aggregate lacks atm_iv_percentile.
Sensibull alone: Greeks + IVP, but ~10–30s snapshot lag for OI; no real bid/ask.
Both: Zerodha drives the engine at tick speed; Sensibull passively enriches each snapshot with per-strike Greeks and aggregate IV fields. No double-counting, no race condition — ownership is explicit.