### PR TITLE
GEX (Gamma Exposure) Analyser for index option chains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,162 @@
+# StockAnalysis — Claude Context
+
+Indian NSE/BSE equity & derivatives intraday/positional analysis system.
+Zerodha KiteConnect WebSocket + Sensibull REST/WS + yfinance + Telegram alerts.
+
+## Commands
+
+```bash
+make venv && make install-dev   # first-time setup
+make run-dev                    # dev intraday loop (PRODUCTION=0 DEV_INTRADAY=1)
+make run-dev-positional         # dev EOD run
+make run-dev-stock-intraday STOCK=RELIANCE   # single stock
+make run-dev-index-intraday INDEX=NIFTY      # single index
+make test                       # full pytest suite
+make test-fast                  # stop on first failure
+make lint                       # ruff check
+make format                     # ruff format
+make typecheck                  # pyright
+make deploy                     # rsync + SSH to production server
+make server-ssh                 # open SSH session to production
+make server-logs-500            # last 500 lines of stock_monitor.log on server
+```
+
+Entry point: `intraday/intraday_monitor.py`
+
+## Architecture
+
+### Analyser Framework
+- `BaseAnalyzer` (decorator pattern): `@BaseAnalyzer.intraday`, `@BaseAnalyzer.positional`, `@BaseAnalyzer.index_intraday`, `@BaseAnalyzer.index_positional`
+- `AnalyserOrchestrator`: collects all registered analysers, calls them in order
+- **Registration order matters** — `OptionSellerCompositeAnalyser` MUST be registered last (reads signals from all other analysers including `PANIC_EXHAUSTION`)
+- Current registration order (10 analysers): VolumeAnalyser → TechnicalAnalyser → CandleStickAnalyser → IVAnalyser → FuturesAnalyser → PCRAnalyser → MaxPainAnalyser → OIChainAnalyser → GEXAnalyser → PanicModeAnalyser → **OptionSellerCompositeAnalyser**
+
+### Scoring & Notifications
+- `ANALYSIS_WEIGHTS` in `common/constants.py` — each signal key has a weight
+- `MIN_NOTIFICATION_SCORE = 110` (intraday), `MIN_NOTIFICATION_SCORE_POSITIONAL = 150` (EOD)
+- `PRIORITY_OVERRIDE` flag bypasses score gate entirely (used by composite setups)
+- `OptionSellerCompositeAnalyser` has weight=0 — never inflates batch scores; bypasses via `PRIORITY_OVERRIDE` only
+- `NEUTRAL_EXCLUDE_FROM_SCORE` — signals excluded from score aggregation (composite keys)
+
+### OPTIONS_SOURCE Modes
+Three modes controlled by `OPTIONS_SOURCE` env var:
+- `zerodha` (default): tick-accurate OI/ltp/depth, no Greeks
+- `sensibull`: Greeks/IV/max pain, ~10-30s snapshots, no auth required
+- `both`: Zerodha is **authoritative** (ltp, OI, engine trigger); Sensibull **enriches only** existing strikes with Greeks/IV
+
+**Critical invariant for `OPTIONS_SOURCE=both`:**
+- `SensibullAdapter.apply(enrichment_only=True)` writes ONLY `{delta, gamma, theta, vega, iv, iv_change}` via `TickStore.update_option_tick(merge=True)`
+- Sensibull NEVER calls `recompute_options_aggregate()` or `on_aggregate_updated()` in this mode — Zerodha owns those
+- `TickStore.update_option_tick(merge=True)` silently skips strikes not yet created by Zerodha (Zerodha is authoritative creator)
+
+### Threading Model
+- `ThreadPoolExecutor` is **module-level** (initialised once in `init()`, not inside `with` block per cycle)
+- `max_workers` defaults to 20 (i5-6200U, I/O-bound); tunable via `THREAD_POOL_WORKERS` env var
+- `price_future.result(timeout=60)` — yfinance bulk download has hard 60s timeout
+- `as_completed(..., timeout=90)` — per-stock analysis batch has hard 90s timeout with future cancellation
+- `_stale_alerts_sent` set is protected by `_stale_alerts_lock` (threading.Lock)
+- `AppContext` singleton (`common/shared.py`) is read-only in worker threads — safe
+
+### Intelligence Layer
+- `SignalBus` (pub/sub) → `SignalCorrelator` (cross-layer confluence detection) → `MarketNarrator` (Gemini Flash LLM)
+- Morning bias: runs positional analysers on 1y daily data before market open, emits signals to `SignalBus`
+- Requires `ENABLE_INTELLIGENCE=1`; LLM requires `ENABLE_NARRATOR=1` + `GEMINI_API_KEY`
+
+## Coding Conventions
+
+- **Never use `print()`** — always `logger.info/debug/warning/error` from `common/logging_util.py`
+- **HTTP timeouts**: always split connect/read — `requests.get(url, timeout=(5, 10))` not `timeout=10`
+- **Env vars**: all defined as constants in `common/constants.py` (e.g. `ENV_PRODUCTION = "PRODUCTION"`); read via `os.getenv(constant.ENV_PRODUCTION)`
+- **`load_dotenv(override=True)`** is called in `init()` — never call it again elsewhere
+- Do not add `@BaseAnalyzer.intraday` / `@BaseAnalyzer.positional` decorators to `OptionSellerCompositeAnalyser` methods — it overrides `run_all_intraday_analyses()` and `run_all_positional_analyses()` directly
+- Python version: **3.12.3** on production server, **3.13.3** on local dev machine
+
+### Analyser Logging Pattern
+
+Every analyser method **must** follow this exact logging structure (see `IVAnalyser.py` and `GEXAnalyser.py` as canonical examples):
+
+```python
+def analyse_signal_name(self, stock: Stock) -> bool:
+    try:
+        logger.debug(f"[SIGNAL_KEY] {stock.stock_symbol} — start")
+
+        # Gate checks (skip silently at DEBUG)
+        if <no data>:
+            logger.debug(f"[SIGNAL_KEY] {stock.stock_symbol} — <reason>, skip")
+            return False
+
+        # Source data log (what raw data was fetched)
+        logger.debug(
+            f"[SIGNAL_KEY] {stock.stock_symbol} | "
+            f"SOURCE <raw_field>=<value> ..."
+        )
+
+        # Condition evaluation log (computed values vs thresholds)
+        logger.debug(
+            f"[SIGNAL_KEY] {stock.stock_symbol} | "
+            f"INPUT <processed>=<value> | "
+            f"CONDITION <value> <op> <threshold>"
+        )
+
+        if <condition met>:
+            stock.set_analysis(...)
+            logger.info(
+                f"[SIGNAL_KEY] {stock.stock_symbol} — EMITTED | "
+                f"<key>=<value> ..."
+            )
+            return True
+
+        logger.debug(
+            f"[SIGNAL_KEY] {stock.stock_symbol} — no signal | "
+            f"<reason why condition failed>"
+        )
+        return False
+
+    except Exception as e:
+        logger.error(f"[SIGNAL_KEY] {stock.stock_symbol} — exception: {e}")
+        logger.error(traceback.format_exc())
+        return False
+```
+
+**Rules:**
+- `[SIGNAL_KEY]` prefix must match the key used in `stock.set_analysis()` and `ANALYSIS_WEIGHTS`
+- `start` log always first line in try block
+- `SOURCE` line: raw input values before any processing
+- `INPUT ... | CONDITION ...` line: computed values and the threshold being tested
+- Signal emitted → `logger.info` with `EMITTED` keyword and key metrics
+- Signal not emitted → `logger.debug` with `no signal | <reason>`
+- All exceptions → `logger.error` + `traceback.format_exc()`
+- Never `logger.info` for skipped/no-signal paths — keep INFO clean for actionable events only
+
+## Environment & Deployment
+
+- **Production server**: `hacker@100.92.21.31` (Tailscale VPN — NOT an EC2 instance, physical machine)
+- **OS**: Ubuntu 24.04.4 LTS, hostname `Hacker-computer`
+- **App dir on server**: `/home/hacker/StockAnalysis`
+- **Log file**: `logs/stock_monitor.log` (local and server)
+- **Systemd timers**: `stockanalysis.timer` (9:00 AM IST) + `stockanalysis-positional.timer` (8:00 PM IST)
+- **Auth service**: `stockanalysis-auth.service` runs `auth/auth_login.py` (TOTP via `pyotp`) before each analysis run, writes fresh `ZERODHA_ENC_TOKEN` to `.env`
+- `.env` is git-ignored; copy `.env.template` and fill in values
+- Do not suggest AWS EC2 CLI commands — deployment uses direct SSH + rsync
+
+## Testing
+
+- Tests in `tests/`, mirrors package structure (e.g. `tests/analyser/`, `tests/common/`)
+- `pytest` with `asyncio_mode = auto` — no `@pytest.mark.asyncio` needed
+- `DeprecationWarning` treated as error except for `telegram`, `anyio`, `pytest_asyncio`
+- Run a single module: `make test-module MODULE=analyser`
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `intraday/intraday_monitor.py` | Main entry point, loop orchestration, `init()`, `fetch_and_analyze_stocks()` |
+| `common/constants.py` | All env var names, scoring weights, thresholds |
+| `common/shared.py` | `AppContext` singleton (`app_ctx`) |
+| `common/Stock.py` | Stock data model (`priceData`, `options_live`, `options_aggregate`, `analysis`) |
+| `analyser/Analyser.py` | `BaseAnalyzer` + `AnalyserOrchestrator` |
+| `analyser/OptionSellerCompositeAnalyser.py` | Cross-analyser composite (GAMMA_TRAP, RANGE_BOUND_SETUP, SKEW_FADE_SETUP) |
+| `fno/sensibull_adapter.py` | Translates Sensibull snapshots → Stock fields (enrichment_only mode) |
+| `zerodha/tick_store.py` | Thread-safe live tick container (`merge=True` for enrichment) |
+| `auth/auth_login.py` | TOTP-based automated Zerodha login |
+| `common/scoring.py` | `calculate_score`, `should_notify`, `NotificationPriority`, `ScoreResult` |

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ help:
 	@echo "    server-logs-follow  Live-follow stock_monitor.log on server"
 	@echo "    server-status       Show stock_analysis.service status"
 	@echo "    server-restart      Restart stock_analysis.service"
+	@echo "    server-stop         Stop stock_analysis.service"
 	@echo "    server-pull         git pull on server repo"
 	@echo "    server-df           Disk usage on server"
 	@echo "    update-enctoken     Update ZERODHA_ENC_TOKEN on server .env:"
@@ -281,6 +282,10 @@ server-status:
 .PHONY: server-restart
 server-restart:
 	ssh $(SERVER) "sudo systemctl restart stockanalysis.service"
+
+.PHONY: server-stop
+server-stop:
+	ssh $(SERVER) "sudo systemctl stop stockanalysis.service"
 
 .PHONY: server-pull
 server-pull:

--- a/analyser/GEXAnalyser.py
+++ b/analyser/GEXAnalyser.py
@@ -1,0 +1,719 @@
+"""
+GEXAnalyser — Gamma Exposure analysis for index option chains.
+
+GEX (Gamma Exposure) measures how much delta-hedging dealers must do when
+spot moves.  Dealers are short whatever retail bought:
+
+    per_strike_gex = (CE_gamma × CE_OI − PE_gamma × PE_OI)
+                     × lot_size × spot² / 1e7   [₹ crores]
+
+    Net GEX = Σ per_strike_gex
+
+    Positive GEX → dealers long gamma → they sell rallies / buy dips → market PINS
+    Negative GEX → dealers short gamma → they amplify moves → market TRENDS
+
+GEX flip level = strike where cumulative GEX (scanning outward from ATM) crosses
+zero.  Above this level the market is in a damping regime; below it the market
+is in an amplifying regime.
+
+Data requirements:
+  • gamma must be present in stock.options_live[strike][CE/PE]
+  • Only populated by Sensibull WS (OPTIONS_SOURCE=sensibull or OPTIONS_SOURCE=both)
+  • In Zerodha-only mode all gamma values are 0 → all methods return False silently
+
+Applies to: LIVE_OPTIONS_INDICES only (NIFTY, BANKNIFTY, SENSEX).
+"""
+
+from __future__ import annotations
+
+import traceback
+from collections import namedtuple
+from statistics import mean, stdev
+
+from analyser.Analyser import BaseAnalyzer
+from common.Stock import Stock
+from common.logging_util import logger
+import common.constants as constant
+import common.shared as shared
+
+# ── Namedtuples ────────────────────────────────────────────────────────────────
+
+GEX_REGIME_NT = namedtuple("GexRegime", [
+    "regime",          # "POSITIVE" | "NEGATIVE"
+    "gex_total",       # float, net GEX in ₹ crores
+    "gex_ce",          # float, CE-side contribution
+    "gex_pe",          # float, PE-side contribution
+    "flip_level",      # float | None, zero-crossing strike
+    "magnitude",       # "MILD" | "MODERATE" | "STRONG"
+    "regime_flipped",  # bool, True when sign changed since last cycle
+    "prev_regime",     # "POSITIVE" | "NEGATIVE" | None
+])
+
+GEX_FLIP_PROXIMITY_NT = namedtuple("GexFlipProximity", [
+    "flip_level",        # float
+    "spot",              # float
+    "distance_pct",      # float, abs % distance from flip level
+    "approaching_from",  # "ABOVE" | "BELOW"
+    "gex_total",         # float, current net GEX
+])
+
+GEX_WALL_NT = namedtuple("GexWall", [
+    "call_walls",         # list[float], sorted by GEX magnitude desc
+    "put_walls",          # list[float]
+    "nearest_call_wall",  # float | None
+    "nearest_put_wall",   # float | None
+    "call_wall_gex",      # float, GEX at nearest call wall
+    "put_wall_gex",       # float, GEX at nearest put wall
+])
+
+GEX_WALL_BREACH_NT = namedtuple("GexWallBreach", [
+    "breach_side",       # "CALL" | "PUT"
+    "breached_strike",   # float
+    "gex_at_strike",     # float, current GEX at that strike
+    "gex_prev_cycle",    # float, GEX at that strike last cycle
+    "gex_drop_pct",      # float, % drop in GEX at this strike
+    "spot",              # float
+    "spot_beyond_pct",   # float, how far spot is past the wall
+])
+
+GEX_IMBALANCE_NT = namedtuple("GexImbalance", [
+    "dominant_side",   # "CE" | "PE"
+    "gex_ce",          # float
+    "gex_pe",          # float
+    "imbalance_ratio", # float
+    "magnitude",       # "MODERATE" | "STRONG" | "EXTREME"
+])
+
+
+class GEXAnalyser(BaseAnalyzer):
+    """Gamma Exposure analyser for index option chains."""
+
+    # ── Thresholds (recalibrated by reset_constants per mode) ──────────────────
+    FLIP_PROXIMITY_THRESHOLD_PCT = 0.4   # % distance from flip level to fire
+    WALL_SIGMA                   = 1.5   # σ multiplier for wall detection
+    WALL_MIN_GEX_CR              = 100   # Min ₹ crores at wall (noise filter)
+    IMBALANCE_RATIO_THRESHOLD    = 2.5   # CE/PE ratio to fire GEX_IMBALANCE
+    IMBALANCE_MIN_SIDE_CR        = 100   # Both sides must exceed this (noise filter)
+    GEX_WALL_BREACH_SPOT_PCT     = 0.3   # Spot must be ≥ this % beyond wall
+    GEX_WALL_BREACH_DROP_PCT     = 30.0  # GEX at strike must drop ≥ this % to confirm
+    GEX_NOISE_FLOOR_CR           = 200   # Below this net GEX is noise; skip flip proximity
+
+    def __init__(self) -> None:
+        self.analyserName = "GEX Analyser"
+        super().__init__()
+
+    def reset_constants(self) -> None:
+        """Calibrate thresholds per mode (intraday = more sensitive)."""
+        is_intraday = shared.app_ctx.mode.name == shared.Mode.INTRADAY.name
+        if is_intraday:
+            GEXAnalyser.FLIP_PROXIMITY_THRESHOLD_PCT = 0.4
+            GEXAnalyser.WALL_SIGMA                   = 1.5
+            GEXAnalyser.WALL_MIN_GEX_CR              = 100
+            GEXAnalyser.GEX_NOISE_FLOOR_CR           = 200
+        else:
+            GEXAnalyser.FLIP_PROXIMITY_THRESHOLD_PCT = 0.6   # wider for EOD gap risk
+            GEXAnalyser.WALL_SIGMA                   = 1.8   # stricter for positional
+            GEXAnalyser.WALL_MIN_GEX_CR              = 200
+            GEXAnalyser.GEX_NOISE_FLOOR_CR           = 300
+        logger.debug(
+            f"[GEXAnalyser] constants reset | mode={'intraday' if is_intraday else 'positional'} "
+            f"flip_prox={GEXAnalyser.FLIP_PROXIMITY_THRESHOLD_PCT}% "
+            f"wall_sigma={GEXAnalyser.WALL_SIGMA} "
+            f"wall_min={GEXAnalyser.WALL_MIN_GEX_CR}Cr "
+            f"noise_floor={GEXAnalyser.GEX_NOISE_FLOOR_CR}Cr"
+        )
+
+    # ── Gate helpers ───────────────────────────────────────────────────────────
+
+    def _is_applicable(self, stock: Stock) -> bool:
+        """Return True only for LIVE_OPTIONS_INDICES with gamma data."""
+        if stock.stock_symbol not in constant.LIVE_OPTIONS_INDICES:
+            return False
+        if not stock.options_live:
+            return False
+        has_gamma = any(
+            data.get("CE", {}).get("gamma", 0.0) or data.get("PE", {}).get("gamma", 0.0)
+            for data in stock.options_live.values()
+        )
+        if not has_gamma:
+            n_strikes = len(stock.options_live)
+            logger.debug(
+                f"[GEXAnalyser] {stock.stock_symbol} — no gamma in options_live "
+                f"(strikes={n_strikes}, OPTIONS_SOURCE may be zerodha-only or "
+                f"Sensibull enrichment not yet received), skip"
+            )
+            return False
+        return True
+
+    # ── Core GEX computation ───────────────────────────────────────────────────
+
+    def _compute_gex(self, stock: Stock) -> tuple[float, float, float, dict, float | None]:
+        """
+        Compute per-strike and aggregate GEX.
+
+        Returns:
+            gex_total, gex_ce, gex_pe, gex_by_strike, flip_level
+        """
+        spot = stock.ltp or 0.0
+        if spot <= 0:
+            return 0.0, 0.0, 0.0, {}, None
+
+        lot_size = constant.INDEX_LOT_SIZES.get(stock.stock_symbol, 1)
+        normaliser = 1e7  # express in ₹ crores
+
+        total_gex_ce = 0.0
+        total_gex_pe = 0.0
+        gex_by_strike: dict[float, float] = {}
+
+        for strike, data in stock.options_live.items():
+            ce = data.get("CE", {})
+            pe = data.get("PE", {})
+
+            ce_gamma = ce.get("gamma", 0.0) or 0.0
+            pe_gamma = pe.get("gamma", 0.0) or 0.0
+            ce_oi    = ce.get("oi", 0) or 0
+            pe_oi    = pe.get("oi", 0) or 0
+
+            gex_ce = ce_gamma * ce_oi * lot_size * (spot ** 2) / normaliser
+            gex_pe = pe_gamma * pe_oi * lot_size * (spot ** 2) / normaliser
+
+            strike_gex = gex_ce - gex_pe
+            gex_by_strike[float(strike)] = strike_gex
+            total_gex_ce += gex_ce
+            total_gex_pe += gex_pe
+
+        gex_total = total_gex_ce - total_gex_pe
+        flip_level = self._find_flip_level(spot, gex_by_strike, gex_total)
+
+        return gex_total, total_gex_ce, total_gex_pe, gex_by_strike, flip_level
+
+    def _find_flip_level(
+        self,
+        spot: float,
+        gex_by_strike: dict[float, float],
+        gex_total: float,
+    ) -> float | None:
+        """
+        Find the strike where cumulative GEX crosses zero.
+        Scans from ATM outward, alternating above/below spot.
+        Returns None if no zero-crossing found within subscribed strikes.
+        """
+        if not gex_by_strike or gex_total == 0.0:
+            return None
+
+        strikes_sorted = sorted(gex_by_strike.keys())
+        if not strikes_sorted:
+            return None
+
+        atm = min(strikes_sorted, key=lambda s: abs(s - spot))
+        atm_idx = strikes_sorted.index(atm)
+
+        cumulative = 0.0
+        prev_cumulative = 0.0
+        for i in range(atm_idx, -1, -1):
+            s = strikes_sorted[i]
+            prev_cumulative = cumulative
+            cumulative += gex_by_strike[s]
+            if prev_cumulative * cumulative < 0:
+                return s
+
+        cumulative = 0.0
+        prev_cumulative = 0.0
+        for i in range(atm_idx, len(strikes_sorted)):
+            s = strikes_sorted[i]
+            prev_cumulative = cumulative
+            cumulative += gex_by_strike[s]
+            if prev_cumulative * cumulative < 0:
+                return s
+
+        return None
+
+    @staticmethod
+    def _magnitude(gex_total: float) -> str:
+        abs_gex = abs(gex_total)
+        if abs_gex >= 2000:
+            return "STRONG"
+        if abs_gex >= 500:
+            return "MODERATE"
+        return "MILD"
+
+    # ── Signal 1: GEX_REGIME (both modes) ─────────────────────────────────────
+
+    @BaseAnalyzer.both
+    @BaseAnalyzer.index_both
+    def analyse_gex_regime(self, stock: Stock) -> bool:
+        """
+        Compute net GEX and emit regime signal. Always fires when gamma is available.
+        Detects regime flips (positive→negative or vice versa) via options_aggregate.
+
+        SOURCE DATA (DEBUG):    options_live[strike][CE/PE] gamma + oi, spot, lot_size
+        ANALYSER INPUT (DEBUG): gex_total, gex_ce, gex_pe, flip_level, prev_regime
+        CONDITION (DEBUG):      gamma present + index in LIVE_OPTIONS_INDICES
+        """
+        try:
+            logger.debug(f"[GEX_REGIME] {stock.stock_symbol} — start")
+
+            if not self._is_applicable(stock):
+                return False
+
+            spot = stock.ltp or 0.0
+            lot_size = constant.INDEX_LOT_SIZES.get(stock.stock_symbol, 1)
+            n_strikes = len(stock.options_live)
+
+            logger.debug(
+                f"[GEX_REGIME] {stock.stock_symbol} | "
+                f"SOURCE strikes={n_strikes}, spot={spot}, lot_size={lot_size}"
+            )
+
+            gex_total, gex_ce, gex_pe, gex_by_strike, flip_level = self._compute_gex(stock)
+
+            new_regime  = "POSITIVE" if gex_total >= 0 else "NEGATIVE"
+            prev_regime = stock.options_aggregate.get("gex_regime")
+            flipped     = prev_regime is not None and prev_regime != new_regime
+            magnitude   = self._magnitude(gex_total)
+
+            logger.debug(
+                f"[GEX_REGIME] {stock.stock_symbol} | "
+                f"INPUT gex_total={gex_total:+.1f}Cr gex_ce={gex_ce:.1f}Cr gex_pe={gex_pe:.1f}Cr | "
+                f"CONDITION regime={new_regime} prev={prev_regime} flipped={flipped} "
+                f"flip_level={flip_level} magnitude={magnitude}"
+            )
+
+            # Persist to options_aggregate for cross-cycle comparisons
+            stock.options_aggregate["gex_total"]      = gex_total
+            stock.options_aggregate["gex_ce"]         = gex_ce
+            stock.options_aggregate["gex_pe"]         = gex_pe
+            stock.options_aggregate["gex_regime"]     = new_regime
+            stock.options_aggregate["gex_flip_level"] = flip_level
+            stock.options_aggregate["gex_by_strike"]  = gex_by_strike
+
+            stock.set_analysis("NEUTRAL", "GEX_REGIME", GEX_REGIME_NT(
+                regime=new_regime,
+                gex_total=round(gex_total, 1),
+                gex_ce=round(gex_ce, 1),
+                gex_pe=round(gex_pe, 1),
+                flip_level=flip_level,
+                magnitude=magnitude,
+                regime_flipped=flipped,
+                prev_regime=prev_regime,
+            ))
+
+            if flipped:
+                logger.info(
+                    f"[GEX_REGIME] {stock.stock_symbol} — REGIME FLIP: "
+                    f"{prev_regime} → {new_regime} | gex={gex_total:+.1f}Cr flip_level={flip_level}"
+                )
+            else:
+                logger.info(
+                    f"[GEX_REGIME] {stock.stock_symbol} — EMITTED | "
+                    f"regime={new_regime} gex={gex_total:+.1f}Cr magnitude={magnitude} flip_level={flip_level}"
+                )
+            return True
+
+        except Exception as e:
+            logger.error(f"[GEX_REGIME] {stock.stock_symbol} — exception: {e}")
+            logger.error(traceback.format_exc())
+            return False
+
+    # ── Signal 2: GEX_FLIP_PROXIMITY (both modes, wider threshold positional) ─
+
+    @BaseAnalyzer.both
+    @BaseAnalyzer.index_both
+    def analyse_gex_flip_proximity(self, stock: Stock) -> bool:
+        """
+        Fire when spot is within FLIP_PROXIMITY_THRESHOLD_PCT of the GEX flip level.
+        Reads flip_level already written by analyse_gex_regime in the same cycle.
+
+        SOURCE DATA (DEBUG):    options_aggregate["gex_flip_level"], stock.ltp
+        ANALYSER INPUT (DEBUG): % distance between spot and flip level
+        CONDITION (DEBUG):      distance < threshold AND |gex_total| > noise floor
+        """
+        try:
+            logger.debug(f"[GEX_FLIP_PROXIMITY] {stock.stock_symbol} — start")
+
+            if not self._is_applicable(stock):
+                return False
+
+            flip_level = stock.options_aggregate.get("gex_flip_level")
+            gex_total  = stock.options_aggregate.get("gex_total", 0.0)
+            spot       = stock.ltp or 0.0
+
+            logger.debug(
+                f"[GEX_FLIP_PROXIMITY] {stock.stock_symbol} | "
+                f"SOURCE flip_level={flip_level}, spot={spot}, gex_total={gex_total:+.1f}Cr"
+            )
+
+            if flip_level is None or spot <= 0:
+                logger.debug(f"[GEX_FLIP_PROXIMITY] {stock.stock_symbol} — no flip level computed, skip")
+                return False
+
+            if abs(gex_total) < GEXAnalyser.GEX_NOISE_FLOOR_CR:
+                logger.debug(
+                    f"[GEX_FLIP_PROXIMITY] {stock.stock_symbol} — "
+                    f"INPUT |gex|={abs(gex_total):.1f}Cr | "
+                    f"CONDITION below noise floor {GEXAnalyser.GEX_NOISE_FLOOR_CR}Cr, skip"
+                )
+                return False
+
+            distance_pct     = abs(spot - flip_level) / flip_level * 100
+            approaching_from = "ABOVE" if spot > flip_level else "BELOW"
+
+            logger.debug(
+                f"[GEX_FLIP_PROXIMITY] {stock.stock_symbol} | "
+                f"INPUT distance={distance_pct:.3f}%, approaching_from={approaching_from} | "
+                f"CONDITION distance <= threshold {GEXAnalyser.FLIP_PROXIMITY_THRESHOLD_PCT}%"
+            )
+
+            if distance_pct <= GEXAnalyser.FLIP_PROXIMITY_THRESHOLD_PCT:
+                stock.set_analysis("NEUTRAL", "GEX_FLIP_PROXIMITY", GEX_FLIP_PROXIMITY_NT(
+                    flip_level=flip_level,
+                    spot=round(spot, 2),
+                    distance_pct=round(distance_pct, 3),
+                    approaching_from=approaching_from,
+                    gex_total=round(gex_total, 1),
+                ))
+                logger.info(
+                    f"[GEX_FLIP_PROXIMITY] {stock.stock_symbol} — EMITTED | "
+                    f"spot={spot} flip={flip_level} dist={distance_pct:.3f}% "
+                    f"approaching_from={approaching_from} gex={gex_total:+.1f}Cr"
+                )
+                return True
+
+            logger.debug(
+                f"[GEX_FLIP_PROXIMITY] {stock.stock_symbol} — no signal | "
+                f"distance={distance_pct:.3f}% > threshold {GEXAnalyser.FLIP_PROXIMITY_THRESHOLD_PCT}%"
+            )
+            return False
+
+        except Exception as e:
+            logger.error(f"[GEX_FLIP_PROXIMITY] {stock.stock_symbol} — exception: {e}")
+            logger.error(traceback.format_exc())
+            return False
+
+    # ── Signal 3: GEX_WALL (both modes) ───────────────────────────────────────
+
+    @BaseAnalyzer.both
+    @BaseAnalyzer.index_both
+    def analyse_gex_wall(self, stock: Stock) -> bool:
+        """
+        Detect gamma concentration walls (mean + WALL_SIGMA σ of per-strike GEX).
+        Call walls → BEARISH bucket (resistance), Put walls → BULLISH bucket (support).
+
+        SOURCE DATA (DEBUG):    options_aggregate["gex_by_strike"]
+        ANALYSER INPUT (DEBUG): distribution stats (mean, sigma, threshold)
+        CONDITION (DEBUG):      strike GEX > threshold, within ±5% of spot, abs GEX > min
+        """
+        try:
+            logger.debug(f"[GEX_WALL] {stock.stock_symbol} — start")
+
+            if not self._is_applicable(stock):
+                return False
+
+            gex_by_strike = stock.options_aggregate.get("gex_by_strike", {})
+            spot = stock.ltp or 0.0
+
+            logger.debug(
+                f"[GEX_WALL] {stock.stock_symbol} | "
+                f"SOURCE strikes={len(gex_by_strike)}, spot={spot}"
+            )
+
+            if len(gex_by_strike) < 5:
+                logger.debug(
+                    f"[GEX_WALL] {stock.stock_symbol} — "
+                    f"too few strikes ({len(gex_by_strike)} < 5), skip"
+                )
+                return False
+
+            if spot <= 0:
+                return False
+
+            values    = list(gex_by_strike.values())
+            mu        = mean(values)
+            sigma     = stdev(values) if len(values) > 1 else 0.0
+            threshold = mu + GEXAnalyser.WALL_SIGMA * sigma
+            range_pct = 0.05
+
+            logger.debug(
+                f"[GEX_WALL] {stock.stock_symbol} | "
+                f"INPUT mean={mu:.1f}Cr sigma={sigma:.1f}Cr | "
+                f"CONDITION threshold={threshold:.1f}Cr (mean + {GEXAnalyser.WALL_SIGMA}σ), "
+                f"range=±{range_pct*100:.0f}% of spot, min={GEXAnalyser.WALL_MIN_GEX_CR}Cr"
+            )
+
+            call_walls: list[tuple[float, float]] = []
+            put_walls:  list[tuple[float, float]] = []
+
+            for strike, sgex in gex_by_strike.items():
+                if abs(strike - spot) / spot > range_pct:
+                    continue
+                abs_gex = abs(sgex)
+                if abs_gex < GEXAnalyser.WALL_MIN_GEX_CR:
+                    continue
+                if abs_gex <= abs(threshold):
+                    continue
+                if sgex > 0:
+                    call_walls.append((strike, sgex))
+                else:
+                    put_walls.append((strike, abs(sgex)))
+
+            call_walls.sort(key=lambda x: x[1], reverse=True)
+            put_walls.sort(key=lambda x: x[1], reverse=True)
+
+            if not call_walls and not put_walls:
+                logger.debug(
+                    f"[GEX_WALL] {stock.stock_symbol} — no signal | "
+                    f"no strike exceeds threshold={threshold:.1f}Cr within ±{range_pct*100:.0f}% of spot"
+                )
+                return False
+
+            nearest_call     = min(call_walls, key=lambda x: abs(x[0] - spot))[0] if call_walls else None
+            nearest_put      = min(put_walls,  key=lambda x: abs(x[0] - spot))[0] if put_walls  else None
+            nearest_call_gex = next((g for s, g in call_walls if s == nearest_call), 0.0)
+            nearest_put_gex  = next((g for s, g in put_walls  if s == nearest_put),  0.0)
+
+            wall_data = GEX_WALL_NT(
+                call_walls=[s for s, _ in call_walls],
+                put_walls=[s for s, _ in put_walls],
+                nearest_call_wall=nearest_call,
+                nearest_put_wall=nearest_put,
+                call_wall_gex=round(nearest_call_gex, 1),
+                put_wall_gex=round(nearest_put_gex, 1),
+            )
+
+            if call_walls:
+                stock.set_analysis("BEARISH", "GEX_WALL", wall_data)
+            if put_walls:
+                stock.set_analysis("BULLISH", "GEX_WALL", wall_data)
+
+            logger.info(
+                f"[GEX_WALL] {stock.stock_symbol} — EMITTED | "
+                f"call_walls={[f'{s:.0f}({g:.0f}Cr)' for s, g in call_walls]} "
+                f"put_walls={[f'{s:.0f}({g:.0f}Cr)' for s, g in put_walls]}"
+            )
+            return True
+
+        except Exception as e:
+            logger.error(f"[GEX_WALL] {stock.stock_symbol} — exception: {e}")
+            logger.error(traceback.format_exc())
+            return False
+
+    # ── Signal 4: GEX_WALL_BREACH (intraday only) ──────────────────────────────
+
+    @BaseAnalyzer.intraday
+    @BaseAnalyzer.index_intraday
+    def analyse_gex_wall_breach(self, stock: Stock) -> bool:
+        """
+        Detect when spot has broken through a GEX wall AND dealer GEX at that
+        strike dropped ≥30% (dealers unwinding confirms the break is real).
+        Needs a previous cycle's gex_by_strike — not applicable positional.
+
+        SOURCE DATA (DEBUG):    current + previous cycle gex_by_strike, spot
+        ANALYSER INPUT (DEBUG): prev_walls identified, per-strike GEX drop %
+        CONDITION (DEBUG):      spot ≥ SPOT_PCT beyond wall + GEX drop ≥ DROP_PCT
+        """
+        try:
+            logger.debug(f"[GEX_WALL_BREACH] {stock.stock_symbol} — start")
+
+            if not self._is_applicable(stock):
+                return False
+
+            curr_gex_by_strike = stock.options_aggregate.get("gex_by_strike", {})
+            prev_gex_by_strike: dict[float, float] = getattr(self, "_prev_gex_by_strike", {}).get(
+                stock.stock_symbol, {}
+            )
+
+            # Persist current for next cycle before any early returns
+            if not hasattr(self, "_prev_gex_by_strike"):
+                self._prev_gex_by_strike = {}
+            self._prev_gex_by_strike[stock.stock_symbol] = dict(curr_gex_by_strike)
+
+            logger.debug(
+                f"[GEX_WALL_BREACH] {stock.stock_symbol} | "
+                f"SOURCE curr_strikes={len(curr_gex_by_strike)}, "
+                f"prev_strikes={len(prev_gex_by_strike)}"
+            )
+
+            if not prev_gex_by_strike:
+                logger.debug(
+                    f"[GEX_WALL_BREACH] {stock.stock_symbol} — no previous cycle data (first run), skip"
+                )
+                return False
+
+            spot = stock.ltp or 0.0
+            if spot <= 0:
+                return False
+
+            prev_values = list(prev_gex_by_strike.values())
+            if len(prev_values) < 5:
+                return False
+            prev_mu     = mean(prev_values)
+            prev_sigma  = stdev(prev_values) if len(prev_values) > 1 else 0.0
+            prev_thresh = prev_mu + GEXAnalyser.WALL_SIGMA * prev_sigma
+            range_pct   = 0.05
+
+            # Find previous cycle walls for logging
+            prev_walls = [
+                (s, g) for s, g in prev_gex_by_strike.items()
+                if abs(s - spot) / spot <= range_pct * 1.5
+                and abs(g) >= GEXAnalyser.WALL_MIN_GEX_CR
+                and abs(g) > abs(prev_thresh)
+            ]
+
+            logger.debug(
+                f"[GEX_WALL_BREACH] {stock.stock_symbol} | "
+                f"INPUT prev_walls={[f'{s:.0f}({g:+.0f}Cr)' for s, g in prev_walls]}, spot={spot} | "
+                f"CONDITION spot_beyond>={GEXAnalyser.GEX_WALL_BREACH_SPOT_PCT}%, "
+                f"gex_drop>={GEXAnalyser.GEX_WALL_BREACH_DROP_PCT}%"
+            )
+
+            found = False
+            for strike, prev_sgex in prev_gex_by_strike.items():
+                if abs(strike - spot) / spot > range_pct * 1.5:
+                    continue
+                if abs(prev_sgex) < GEXAnalyser.WALL_MIN_GEX_CR:
+                    continue
+                if abs(prev_sgex) <= abs(prev_thresh):
+                    continue
+
+                curr_sgex = curr_gex_by_strike.get(strike, 0.0)
+
+                if abs(prev_sgex) > 0:
+                    gex_drop_pct = (abs(prev_sgex) - abs(curr_sgex)) / abs(prev_sgex) * 100
+                else:
+                    continue
+                if gex_drop_pct < GEXAnalyser.GEX_WALL_BREACH_DROP_PCT:
+                    logger.debug(
+                        f"[GEX_WALL_BREACH] {stock.stock_symbol} | "
+                        f"strike={strike:.0f} gex_drop={gex_drop_pct:.1f}% < "
+                        f"threshold {GEXAnalyser.GEX_WALL_BREACH_DROP_PCT}% — dealers still defending"
+                    )
+                    continue
+
+                if prev_sgex > 0 and spot > strike:
+                    spot_beyond_pct = (spot - strike) / strike * 100
+                    if spot_beyond_pct >= GEXAnalyser.GEX_WALL_BREACH_SPOT_PCT:
+                        stock.set_analysis("BULLISH", "GEX_WALL_BREACH", GEX_WALL_BREACH_NT(
+                            breach_side="CALL",
+                            breached_strike=strike,
+                            gex_at_strike=round(curr_sgex, 1),
+                            gex_prev_cycle=round(prev_sgex, 1),
+                            gex_drop_pct=round(gex_drop_pct, 1),
+                            spot=round(spot, 2),
+                            spot_beyond_pct=round(spot_beyond_pct, 2),
+                        ))
+                        logger.info(
+                            f"[GEX_WALL_BREACH] {stock.stock_symbol} — CALL WALL BREACH EMITTED | "
+                            f"strike={strike:.0f} spot={spot:.2f} beyond={spot_beyond_pct:.2f}% "
+                            f"gex: {prev_sgex:+.0f}→{curr_sgex:+.0f}Cr (drop={gex_drop_pct:.1f}%)"
+                        )
+                        found = True
+
+                elif prev_sgex < 0 and spot < strike:
+                    spot_beyond_pct = (strike - spot) / strike * 100
+                    if spot_beyond_pct >= GEXAnalyser.GEX_WALL_BREACH_SPOT_PCT:
+                        stock.set_analysis("BEARISH", "GEX_WALL_BREACH", GEX_WALL_BREACH_NT(
+                            breach_side="PUT",
+                            breached_strike=strike,
+                            gex_at_strike=round(curr_sgex, 1),
+                            gex_prev_cycle=round(prev_sgex, 1),
+                            gex_drop_pct=round(gex_drop_pct, 1),
+                            spot=round(spot, 2),
+                            spot_beyond_pct=round(spot_beyond_pct, 2),
+                        ))
+                        logger.info(
+                            f"[GEX_WALL_BREACH] {stock.stock_symbol} — PUT WALL BREACH EMITTED | "
+                            f"strike={strike:.0f} spot={spot:.2f} beyond={spot_beyond_pct:.2f}% "
+                            f"gex: {prev_sgex:+.0f}→{curr_sgex:+.0f}Cr (drop={gex_drop_pct:.1f}%)"
+                        )
+                        found = True
+
+            if not found:
+                logger.debug(
+                    f"[GEX_WALL_BREACH] {stock.stock_symbol} — no signal | "
+                    f"no wall broken with spot_beyond>={GEXAnalyser.GEX_WALL_BREACH_SPOT_PCT}% "
+                    f"and gex_drop>={GEXAnalyser.GEX_WALL_BREACH_DROP_PCT}%"
+                )
+            return found
+
+        except Exception as e:
+            logger.error(f"[GEX_WALL_BREACH] {stock.stock_symbol} — exception: {e}")
+            logger.error(traceback.format_exc())
+            return False
+
+    # ── Signal 5: GEX_IMBALANCE (both modes) ──────────────────────────────────
+
+    @BaseAnalyzer.both
+    @BaseAnalyzer.index_both
+    def analyse_gex_imbalance(self, stock: Stock) -> bool:
+        """
+        Fire when CE or PE gamma dominates by ≥2.5x — dealers must delta-hedge
+        aggressively on one side, creating a persistent directional headwind.
+
+        SOURCE DATA (DEBUG):    options_aggregate["gex_ce"] / ["gex_pe"]
+        ANALYSER INPUT (DEBUG): CE/PE GEX ratio
+        CONDITION (DEBUG):      ratio > IMBALANCE_RATIO_THRESHOLD, both sides > min floor
+        """
+        try:
+            logger.debug(f"[GEX_IMBALANCE] {stock.stock_symbol} — start")
+
+            if not self._is_applicable(stock):
+                return False
+
+            gex_ce = stock.options_aggregate.get("gex_ce", 0.0)
+            gex_pe = stock.options_aggregate.get("gex_pe", 0.0)
+
+            logger.debug(
+                f"[GEX_IMBALANCE] {stock.stock_symbol} | "
+                f"SOURCE gex_ce={gex_ce:.1f}Cr gex_pe={gex_pe:.1f}Cr"
+            )
+
+            if gex_ce < GEXAnalyser.IMBALANCE_MIN_SIDE_CR or gex_pe < GEXAnalyser.IMBALANCE_MIN_SIDE_CR:
+                logger.debug(
+                    f"[GEX_IMBALANCE] {stock.stock_symbol} — no signal | "
+                    f"one side below noise floor {GEXAnalyser.IMBALANCE_MIN_SIDE_CR}Cr "
+                    f"(ce={gex_ce:.1f} pe={gex_pe:.1f})"
+                )
+                return False
+
+            if gex_ce >= gex_pe * GEXAnalyser.IMBALANCE_RATIO_THRESHOLD:
+                ratio    = gex_ce / gex_pe
+                dominant = "CE"
+                bucket   = "BEARISH"
+            elif gex_pe >= gex_ce * GEXAnalyser.IMBALANCE_RATIO_THRESHOLD:
+                ratio    = gex_pe / gex_ce
+                dominant = "PE"
+                bucket   = "BULLISH"
+            else:
+                logger.debug(
+                    f"[GEX_IMBALANCE] {stock.stock_symbol} — no signal | "
+                    f"INPUT ratio={max(gex_ce, gex_pe) / min(gex_ce, gex_pe):.2f}x | "
+                    f"CONDITION below threshold {GEXAnalyser.IMBALANCE_RATIO_THRESHOLD}x"
+                )
+                return False
+
+            magnitude = "EXTREME" if ratio > 6.0 else "STRONG" if ratio > 4.0 else "MODERATE"
+
+            logger.debug(
+                f"[GEX_IMBALANCE] {stock.stock_symbol} | "
+                f"INPUT ratio={ratio:.2f}x dominant={dominant} | "
+                f"CONDITION ratio >= threshold {GEXAnalyser.IMBALANCE_RATIO_THRESHOLD}x → {magnitude}"
+            )
+
+            stock.set_analysis(bucket, "GEX_IMBALANCE", GEX_IMBALANCE_NT(
+                dominant_side=dominant,
+                gex_ce=round(gex_ce, 1),
+                gex_pe=round(gex_pe, 1),
+                imbalance_ratio=round(ratio, 2),
+                magnitude=magnitude,
+            ))
+            logger.info(
+                f"[GEX_IMBALANCE] {stock.stock_symbol} — EMITTED [{bucket}] | "
+                f"dominant={dominant} ratio={ratio:.2f}x magnitude={magnitude} "
+                f"(ce={gex_ce:.1f}Cr pe={gex_pe:.1f}Cr)"
+            )
+            return True
+
+        except Exception as e:
+            logger.error(f"[GEX_IMBALANCE] {stock.stock_symbol} — exception: {e}")
+            logger.error(traceback.format_exc())
+            return False

--- a/analyser/MessageFormatter.py
+++ b/analyser/MessageFormatter.py
@@ -677,24 +677,40 @@ def _mode_tag(mode_str) -> str:
 
 @MessageFormatter.register("GAMMA_TRAP")
 def _fmt_gamma_trap(data, trend):
-    """
-    GAMMA_TRAP — Kill-switch card.
-    Rendered with maximum urgency: red header, bold directive, condition list.
-    """
     items = data if isinstance(data, list) else [data]
     lines = []
     for d in items:
         dir_arrow = "⬆️" if d.direction == "BULLISH" else "⬇️"
-        conds = ", ".join(d.conditions_detail)
-        vol_str = f" | Vol: <b>{d.volume_signal}</b>" if d.volume_signal else ""
+        _all_conditions = ["G1 Wall Breach", "G2 Volume", "G3 Futures", "G4 IV Spike"]
+        triggers = getattr(d, "triggers", {})
+
+        cond_lines = []
+        for ckey in _all_conditions:
+            metric = triggers.get(ckey)
+            # Map trigger key back to conditions_detail label fragments
+            _detail_map = {
+                "G1 Wall Breach": ("OI_CAPITULATION", "OI_WALL_MIGRATION", "GEX_WALL_BREACH"),
+                "G2 Volume":      ("VOLUME_BREAKOUT", "VOLUME_CLIMAX"),
+                "G3 Futures":     ("FUTURES(",),
+                "G4 IV Spike":    ("IV_SPIKE",),
+            }
+            fired = any(
+                any(frag in cd for frag in _detail_map.get(ckey, ()))
+                for cd in d.conditions_detail
+            )
+            label = ckey.split(" ", 1)[1]  # strip "G1 " prefix
+            if fired and metric:
+                cond_lines.append(f"  ✅ {label} — {metric}")
+            elif fired:
+                cond_lines.append(f"  ✅ {label}")
+            else:
+                cond_lines.append(f"  ❌ {label} — not detected")
 
         lines += [
-            f"  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
-            f"  🚨 <b>GAMMA TRAP — CLOSE SHORTS NOW</b>",
-            f"  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+            f"  🚨 <b>GAMMA TRAP — CLOSE SHORTS NOW</b>  "
+            f"[<code>{d.conditions_met}/4</code>]",
             f"  Direction: {dir_arrow} <b>{d.direction}</b> breakout confirmed",
-            f"  Breach: <b>{d.breach_signal}</b>{vol_str}",
-            f"  Conditions: <code>{d.conditions_met}/4</code> — {conds}",
+            *cond_lines,
             f"  ⏱ Mode: <i>{_mode_tag(d.mode)}</i>",
         ]
     return lines
@@ -702,87 +718,54 @@ def _fmt_gamma_trap(data, trend):
 
 @MessageFormatter.register("RANGE_BOUND_SETUP")
 def _fmt_range_bound(data, trend):
-    """
-    RANGE_BOUND_SETUP — Iron Condor / Strangle trade card.
-    Shows the box range (walls), IV context, max pain proximity, and conditions.
-    """
-    # Human-readable labels for each condition code
-    _cond_labels = {
-        "OVERPRICED_VOL":   "IV overpriced (sell premium)",
-        "CEILING_AND_FLOOR": "Put wall floor + Call wall ceiling in place",
-        "NEUTRAL_MOMENTUM": "No breakout signal — price momentum flat",
-        "NO_INSTIT_PUSH":   "No institutional futures buildup (no directional bias)",
-        "MAX_PAIN_MAGNET":  "Price inside max pain gravity zone",
-    }
+    _setup_labels = {"IRON_CONDOR": "Iron Condor", "STRANGLE": "Strangle"}
 
-    # Human-readable setup type
-    _setup_labels = {
-        "IRON_CONDOR": "Iron Condor",
-        "STRANGLE":    "Strangle",
-    }
+    # condition key → (display label, trigger key)
+    _all_conditions = [
+        ("OVERPRICED_VOL",      "IV overpriced",           "R1 IV"),
+        ("CEILING_AND_FLOOR",   "OI walls",                "R2 OI Walls"),
+        ("NEUTRAL_MOMENTUM",    "Neutral momentum",        "R3 Momentum"),
+        ("NO_INSTIT_PUSH",      "No institutional push",   "R4 Futures"),
+        ("MAX_PAIN_MAGNET",     "Max pain magnet",         "R5 MaxPain"),
+        ("GEX_POSITIVE_REGIME", "GEX positive regime",     "R6 GEX"),
+    ]
 
     items = data if isinstance(data, list) else [data]
     lines = []
     for d in items:
         setup_label = _setup_labels.get(d.setup_type, d.setup_type)
+        triggers = getattr(d, "triggers", {})
 
-        # ── Box range line ────────────────────────────────────────────────────
+        # ── Box range line (always shown) ─────────────────────────────────────
         if d.put_wall_strike and d.call_wall_strike:
             box_width_pct = (d.call_wall_strike - d.put_wall_strike) / d.put_wall_strike * 100
-            range_line = (
-                f"  📦 Box:    <code>{d.put_wall_strike:.0f}</code> ←──→ "
+            box_line = (
+                f"  📦 Box: <code>{d.put_wall_strike:.0f}</code> ←──→ "
                 f"<code>{d.call_wall_strike:.0f}</code>  "
                 f"(<code>{box_width_pct:.1f}%</code> wide)"
             )
         elif d.put_wall_strike:
-            range_line = f"  📦 Floor:  <code>{d.put_wall_strike:.0f}</code> (put wall — ceiling not detected)"
+            box_line = f"  📦 Floor: <code>{d.put_wall_strike:.0f}</code> (ceiling not detected)"
         elif d.call_wall_strike:
-            range_line = f"  📦 Ceiling: <code>{d.call_wall_strike:.0f}</code> (call wall — floor not detected)"
+            box_line = f"  📦 Ceiling: <code>{d.call_wall_strike:.0f}</code> (floor not detected)"
         else:
-            range_line = "  📦 Box: walls present (strikes unavailable)"
+            box_line = "  📦 Box: walls present (strikes unavailable)"
 
-        # ── IV line: IV Percentile + what it means for option sellers ─────────
-        if d.iv_percentile is not None:
-            ivp = d.iv_percentile
-            if ivp >= 85:
-                iv_context = "extremely overpriced — strong edge to sell"
-            elif ivp >= 70:
-                iv_context = "overpriced — good edge to sell"
+        # ── Unified condition + metric lines ──────────────────────────────────
+        cond_lines = []
+        total = len(_all_conditions)
+        for (ckey, label, tkey) in _all_conditions:
+            fired = ckey in d.conditions_detail
+            metric = triggers.get(tkey, "")
+            if fired:
+                cond_lines.append(f"  ✅ {label}" + (f" — {metric}" if metric else ""))
             else:
-                iv_context = "elevated"
-            iv_line = (
-                f"  📊 IV:     IVP <code>{ivp:.0f}th</code> percentile — {iv_context}"
-            )
-        else:
-            iv_line = "  📊 IV:     Premium confirmed overpriced"
-
-        # ── Max pain line ─────────────────────────────────────────────────────
-        if d.max_pain_dev_pct is not None:
-            dev = d.max_pain_dev_pct
-            direction_word = "above" if dev > 0 else "below"
-            mp_line = (
-                f"  🧲 MaxPain: <code>{abs(dev):.1f}%</code> {direction_word} max pain "
-                f"— price likely to gravitate back"
-            )
-        else:
-            mp_line = "  🧲 MaxPain: Within gravity zone"
-
-        # ── Conditions: translate each code to plain English ─────────────────
-        cond_lines = [
-            f"  {'✅' if c in d.conditions_detail else '❌'} {_cond_labels.get(c, c)}"
-            for c in ("OVERPRICED_VOL", "CEILING_AND_FLOOR", "NEUTRAL_MOMENTUM",
-                      "NO_INSTIT_PUSH", "MAX_PAIN_MAGNET")
-        ]
+                cond_lines.append(f"  ❌ {label} — not confirmed")
 
         lines += [
-            f"  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
             f"  🎯 <b>RANGE PREMIUM — {setup_label}</b>  "
-            f"[<code>{d.conditions_met}/5</code> conditions]",
-            f"  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
-            range_line,
-            iv_line,
-            mp_line,
-            f"  ─────────────────────────────────",
+            f"[<code>{d.conditions_met}/{total}</code>]",
+            box_line,
             *cond_lines,
             f"  ⏱ Mode: <i>{_mode_tag(d.mode)}</i>",
         ]
@@ -791,47 +774,122 @@ def _fmt_range_bound(data, trend):
 
 @MessageFormatter.register("SKEW_FADE_SETUP")
 def _fmt_skew_fade(data, trend):
+    items = data if isinstance(data, list) else [data]
+    lines = []
+    for d in items:
+        fade_arrow = "⬆️" if d.fade_direction == "BULLISH" else "⬇️"
+        triggers = getattr(d, "triggers", {})
+
+        cond_lines = []
+        for tkey, label in [
+            ("S1 Exhaustion", "Exhaustion"),
+            ("S2 SR Wall",    "SR wall"),
+            ("S3 PCR Trap",   "PCR trap"),
+        ]:
+            metric = triggers.get(tkey, "")
+            cond_lines.append(f"  ✅ {label} — {metric}" if metric else f"  ✅ {label}")
+
+        lines += [
+            f"  ⚔️ <b>SKEW FADE — {d.fade_direction} CREDIT SPREAD</b>  [3/3]",
+            *cond_lines,
+            f"  Trade: {fade_arrow} Sell {d.panic_direction.lower()} side → "
+            f"<b>{d.fade_direction}</b> credit spread",
+            f"  ⏱ Mode: <i>{_mode_tag(d.mode)}</i>",
+        ]
+    return lines
+
+
+# ── GEX Formatters ─────────────────────────────────────────────────────────────
+
+@MessageFormatter.register("GEX_REGIME")
+def _fmt_gex_regime(data, trend):
     """
-    SKEW_FADE_SETUP — Directional credit spread trade card.
-    Shows the fade direction, exhaustion context, the SR wall being tested,
-    the confirming candle, and the PCR trap that completes the setup.
+    GEX_REGIME — Gamma regime context card (informational, not a trade card).
+    Rendered prominently only when regime has flipped; otherwise compact.
     """
     items = data if isinstance(data, list) else [data]
     lines = []
     for d in items:
-        fade_arrow  = "⬆️" if d.fade_direction == "BULLISH" else "⬇️"
-        panic_arrow = "⬇️" if d.panic_direction == "BEARISH" else "⬆️"
+        regime_emoji = "🟢" if d.regime == "POSITIVE" else "🔴"
+        regime_label = "POSITIVE — dealers long gamma (market PINS)" if d.regime == "POSITIVE" \
+                       else "NEGATIVE — dealers short gamma (market TRENDS)"
 
-        # Human-readable candle key
-        _candle_labels = {
-            "Double_candle_stick_pattern":    "Engulfing/Piercing (2-bar reversal)",
-            "Single_candle_reversal_pattern": "Hammer/Shooting Star",
-            "Triple_candle_stick_pattern":    "Morning/Evening Star (3-bar reversal)",
-            "Triple_candle_reversal_pattern": "Triple reversal pattern",
-        }
-        candle_label = _candle_labels.get(d.candle_key, d.candle_key)
+        mag_context = {
+            "MILD":     "weak signal, low conviction",
+            "MODERATE": "moderate conviction",
+            "STRONG":   "high conviction",
+        }.get(d.magnitude, d.magnitude)
 
-        # Human-readable PCR signal
-        _pcr_labels = {
-            "PCR_REVERSAL":       "PCR zone crossover (intraday)",
-            "PCR_POS_REVERSAL":   "PCR 3-day avg reversal (positional)",
-            "PCR_INTRADAY_TREND": "PCR intraday momentum shift",
-        }
-        pcr_label = _pcr_labels.get(d.pcr_signal, d.pcr_signal)
+        flip_str = (
+            f"  🔄 <b>REGIME FLIP</b>: {d.prev_regime} → <b>{d.regime}</b>\n"
+            if d.regime_flipped else ""
+        )
+        lines += [
+            f"  {regime_emoji} <b>GEX REGIME</b>: {regime_label}",
+        ]
+        if d.regime_flipped:
+            lines.append(f"  🔄 <b>REGIME FLIP</b>: {d.prev_regime} → <b>{d.regime}</b>")
+        lines += [
+            f"  📊 Net GEX:  <code>{d.gex_total:+.0f} Cr</code>  "
+            f"[CE: <code>{d.gex_ce:.0f}</code>  PE: <code>{d.gex_pe:.0f}</code>]  "
+            f"— {mag_context}",
+        ]
+        if d.flip_level:
+            lines.append(
+                f"  🎯 Flip level: <code>{d.flip_level:.0f}</code> "
+                f"(above = pin, below = trend)"
+            )
+    return lines
+
+
+@MessageFormatter.register("GEX_WALL_BREACH")
+def _fmt_gex_wall_breach(data, trend):
+    """
+    GEX_WALL_BREACH — Directional breach confirmed by dealer gamma unwind.
+    High-conviction: spot crossed a gamma wall AND dealers stopped defending.
+    """
+    items = data if isinstance(data, list) else [data]
+    lines = []
+    for d in items:
+        dir_arrow = "⬆️" if d.breach_side == "CALL" else "⬇️"
+        dir_label = "BULLISH breakout" if d.breach_side == "CALL" else "BEARISH breakdown"
+        wall_label = "call wall" if d.breach_side == "CALL" else "put wall"
 
         lines += [
-            f"  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
-            f"  ⚔️ <b>SKEW FADE — {d.fade_direction} CREDIT SPREAD</b>  "
-            f"[3/3]",
-            f"  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
-            f"  Exhaust:  {panic_arrow} <b>{d.panic_direction}</b> panic burning out "
-            f"[<b>{d.exhaustion_confidence}</b>]",
-            f"  Wall:     {fade_arrow} SR at <code>{d.sr_level:.0f}</code> "
-            f"(<code>{d.sr_proximity_pct:.2f}%</code> away) | "
-            f"Candle: <i>{candle_label}</i>",
-            f"  PCR Trap: {pcr_label}",
-            f"  Trade:    Sell {d.panic_direction.lower()} side → "
-            f"<b>{d.fade_direction}</b> credit spread",
-            f"  ⏱ Mode: <i>{_mode_tag(d.mode)}</i>",
+            f"  {dir_arrow} <b>GEX WALL BREACH — {dir_label}</b>",
+            f"  🧱 Breached {wall_label}: <code>{d.breached_strike:.0f}</code>",
+            f"  📍 Spot:    <code>{d.spot:.2f}</code>  "
+            f"(<code>{d.spot_beyond_pct:.2f}%</code> beyond wall)",
+            f"  📉 Dealer GEX at strike: "
+            f"<code>{d.gex_prev_cycle:+.1f} Cr</code> → "
+            f"<code>{d.gex_at_strike:+.1f} Cr</code>  "
+            f"(dropped <b>{d.gex_drop_pct:.0f}%</b> — dealers stopped defending)",
+        ]
+    return lines
+
+
+@MessageFormatter.register("GEX_IMBALANCE")
+def _fmt_gex_imbalance(data, trend):
+    """
+    GEX_IMBALANCE — CE or PE gamma dominance creating a persistent directional headwind.
+    """
+    items = data if isinstance(data, list) else [data]
+    lines = []
+    for d in items:
+        if d.dominant_side == "CE":
+            dir_emoji = "🔴"
+            headwind = "dealers must SELL every rally aggressively (bearish headwind)"
+        else:
+            dir_emoji = "🟢"
+            headwind = "dealers must BUY every dip aggressively (bullish floor)"
+
+        mag_emoji = {"MODERATE": "⚠️", "STRONG": "🔥", "EXTREME": "💥"}.get(d.magnitude, "")
+
+        lines += [
+            f"  {dir_emoji} <b>GEX IMBALANCE</b> — {mag_emoji} {d.magnitude}",
+            f"  📊 CE GEX: <code>{d.gex_ce:.0f} Cr</code>  "
+            f"PE GEX: <code>{d.gex_pe:.0f} Cr</code>  "
+            f"Ratio: <b>{d.imbalance_ratio:.1f}x</b> ({d.dominant_side} dominant)",
+            f"  ⚡ {headwind}",
         ]
     return lines

--- a/analyser/OptionSellerCompositeAnalyser.py
+++ b/analyser/OptionSellerCompositeAnalyser.py
@@ -36,14 +36,19 @@ import common.shared as shared
 # ── Output namedtuples (module-level: not recreated on every call) ────────────
 
 RANGE_BOUND_SETUP_NT = namedtuple("RangeBoundSetup", [
-    "conditions_met",    # int : number of conditions that fired (4 or 5)
+    "conditions_met",    # int : number of conditions that fired (out of 6)
     "conditions_detail", # list[str] : human-readable names of fired conditions
     "iv_percentile",     # float | None : IVP from IV_RANK_EXTREME or IV_RANK
+    "iv_trigger",        # str | None : "IV_RANK" | "IV_PREMIUM" — which signal fired R1
+    "iv_hv_ratio",       # float | None : IV/HV ratio (only when iv_trigger="IV_PREMIUM")
+    "iv_premium_pct",    # float | None : IV premium % above HV (only when iv_trigger="IV_PREMIUM")
     "put_wall_strike",   # float | None : nearest put wall strike (floor)
     "call_wall_strike",  # float | None : nearest call wall strike (ceiling)
     "max_pain_dev_pct",  # float | None : spot % deviation from max pain
     "setup_type",        # str : "IRON_CONDOR" (both walls) | "STRANGLE"
     "mode",              # str : app_ctx.mode.value
+    "gex_supports",      # bool : True when GEX regime is POSITIVE + MODERATE/STRONG
+    "triggers",          # dict[str, str] : {condition_name: metric_string} for fired conditions
 ])
 
 SKEW_FADE_SETUP_NT = namedtuple("SkewFadeSetup", [
@@ -56,6 +61,7 @@ SKEW_FADE_SETUP_NT = namedtuple("SkewFadeSetup", [
     "candle_key",            # str : analysis key of the confirming candle pattern
     "pcr_signal",            # str : which PCR key confirmed ("PCR_REVERSAL" etc.)
     "mode",                  # str
+    "triggers",              # dict[str, str] : {condition_name: metric_string}
 ])
 
 GAMMA_TRAP_NT = namedtuple("GammaTrap", [
@@ -65,6 +71,7 @@ GAMMA_TRAP_NT = namedtuple("GammaTrap", [
     "breach_signal",     # str : "OI_CAPITULATION" | "OI_WALL_MIGRATION"
     "volume_signal",     # str : "VOLUME_BREAKOUT" | "VOLUME_CLIMAX" | None
     "mode",              # str
+    "triggers",          # dict[str, str] : {condition_name: metric_string}
 ])
 
 
@@ -194,10 +201,11 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
         """
         try:
             logger.debug(f"[GAMMA_TRAP] {stock.stock_symbol} — start")
-            conditions:  list[str] = []
+            conditions:   list[str] = []
+            triggers:     dict[str, str] = {}
             breach_signal: str | None = None
             volume_signal: str | None = None
-            direction:     str | None = None  # direction of the move
+            direction:     str | None = None
 
             # ── G1: Wall Breach ───────────────────────────────────────────────
             # OI_CAPITULATION: either side unwinding = directional clearing
@@ -206,12 +214,18 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
             if self._any(cap_bull) or self._any(cap_bear):
                 conditions.append("OI_CAPITULATION")
                 breach_signal = "OI_CAPITULATION"
-                # Direction = toward the capitulating side
-                # CALL capitulation (unwinding) → bullish move; PUT cap → bearish
                 cap_data = cap_bull or cap_bear
                 items = cap_data if isinstance(cap_data, list) else [cap_data]
                 side = getattr(items[0], "side", "CALL") if items else "CALL"
                 direction = "BULLISH" if side == "CALL" else "BEARISH"
+                unwound_pct = getattr(items[0], "unwound_pct", None)
+                top_strikes = getattr(items[0], "top_strikes", [])
+                metric = f"{side} OI unwound"
+                if unwound_pct is not None:
+                    metric += f" {unwound_pct:.0f}%"
+                if top_strikes:
+                    metric += f" near {top_strikes[0]}"
+                triggers["G1 Wall Breach"] = metric
             else:
                 # OI_WALL_MIGRATION with an actual shift (not RETREAT) is a proxy breach
                 for sentiment in ("BULLISH", "BEARISH"):
@@ -228,12 +242,44 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
                             conditions.append("OI_WALL_MIGRATION(CALL_HIGHER)")
                             breach_signal = "OI_WALL_MIGRATION"
                             direction = "BULLISH"
+                            mpts = getattr(m, "migration_pts", None)
+                            triggers["G1 Wall Breach"] = f"CALL wall migrated HIGHER" + (f" +{mpts:.0f}pts" if mpts else "")
                             break
                         elif side == "PUT" and mdir == "LOWER":
                             conditions.append("OI_WALL_MIGRATION(PUT_LOWER)")
                             breach_signal = "OI_WALL_MIGRATION"
                             direction = "BEARISH"
+                            mpts = getattr(m, "migration_pts", None)
+                            triggers["G1 Wall Breach"] = f"PUT wall migrated LOWER" + (f" {mpts:.0f}pts" if mpts else "")
                             break
+                    if breach_signal:
+                        break
+
+            # GEX_WALL_BREACH: dealer GEX confirmed drop — additive G1 confirmation.
+            # Direction inferred from breach_side (CALL breach → bullish, PUT breach → bearish).
+            if not breach_signal:
+                for sentiment in ("BULLISH", "BEARISH"):
+                    gex_breach = self._get(stock, sentiment, "GEX_WALL_BREACH")
+                    if self._any(gex_breach):
+                        items = gex_breach if isinstance(gex_breach, list) else [gex_breach]
+                        for b in items:
+                            bside = getattr(b, "breach_side", "")
+                            if bside == "CALL":
+                                conditions.append("GEX_WALL_BREACH(CALL)")
+                                breach_signal = "GEX_WALL_BREACH"
+                                direction = "BULLISH"
+                                drop = getattr(b, "gex_drop_pct", None)
+                                strike = getattr(b, "breached_strike", None)
+                                triggers["G1 Wall Breach"] = f"GEX CALL wall {strike:.0f} broken" + (f", dealer GEX dropped {drop:.0f}%" if drop else "")
+                            elif bside == "PUT":
+                                conditions.append("GEX_WALL_BREACH(PUT)")
+                                breach_signal = "GEX_WALL_BREACH"
+                                direction = "BEARISH"
+                                drop = getattr(b, "gex_drop_pct", None)
+                                strike = getattr(b, "breached_strike", None)
+                                triggers["G1 Wall Breach"] = f"GEX PUT wall {strike:.0f} broken" + (f", dealer GEX dropped {drop:.0f}%" if drop else "")
+                            if breach_signal:
+                                break
                     if breach_signal:
                         break
 
@@ -244,13 +290,21 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
             # ── G2: Volume Surge ──────────────────────────────────────────────
             # Check in the direction of the move first, then either direction
             for sentiment in (direction, "BULLISH", "BEARISH"):
-                if self._any(self._get(stock, sentiment, "VOLUME_BREAKOUT")):
+                vb = self._get(stock, sentiment, "VOLUME_BREAKOUT")
+                if self._any(vb):
                     conditions.append("VOLUME_BREAKOUT")
                     volume_signal = "VOLUME_BREAKOUT"
+                    vb_item = (vb[0] if isinstance(vb, list) else vb)
+                    ratio = getattr(vb_item, "volume_ratio", None)
+                    triggers["G2 Volume"] = "BREAKOUT" + (f" {ratio:.1f}× avg" if ratio else "")
                     break
-                if self._any(self._get(stock, sentiment, "VOLUME_CLIMAX")):
+                vc = self._get(stock, sentiment, "VOLUME_CLIMAX")
+                if self._any(vc):
                     conditions.append("VOLUME_CLIMAX")
                     volume_signal = "VOLUME_CLIMAX"
+                    vc_item = (vc[0] if isinstance(vc, list) else vc)
+                    ratio = getattr(vc_item, "volume_ratio", None)
+                    triggers["G2 Volume"] = "CLIMAX" + (f" {ratio:.1f}× avg" if ratio else "")
                     break
 
             # ── G3: Futures Fuel ──────────────────────────────────────────────
@@ -265,15 +319,25 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
             fut_found = False
             keys_to_check = fut_keys_bullish if direction == "BULLISH" else fut_keys_bearish
             for key in keys_to_check:
-                if self._any(self._get(stock, direction, key)):
+                fd = self._get(stock, direction, key)
+                if self._any(fd):
                     conditions.append(f"FUTURES({key})")
                     fut_found = True
+                    fd_item = (fd[0] if isinstance(fd, list) else fd)
+                    oi_pct = getattr(fd_item, "oi_percentage", None) or getattr(fd_item, "oi_change_pct", None)
+                    label = key.replace("FUTURE_BREAKOUT_", "").replace("FUTURE_ACTION_", "").replace("_", " ").title()
+                    triggers["G3 Futures"] = label + (f" OI +{oi_pct:.1f}%" if oi_pct else "")
                     break
 
             # ── G4: Volatility Expansion ──────────────────────────────────────
-            iv_found = self._any(self._get(stock, "NEUTRAL", "IV_SPIKE"))
+            iv_data = self._get(stock, "NEUTRAL", "IV_SPIKE")
+            iv_found = self._any(iv_data)
             if iv_found:
                 conditions.append("IV_SPIKE")
+                iv_item = (iv_data[0] if isinstance(iv_data, list) else iv_data)
+                iv_val = getattr(iv_item, "atm_iv", None) or getattr(iv_item, "iv", None)
+                iv_chg = getattr(iv_item, "atm_iv_change", None) or getattr(iv_item, "iv_change", None)
+                triggers["G4 IV Spike"] = "IV spike" + (f" ATM IV {iv_val:.1f}" if iv_val else "") + (f" (+{iv_chg:.1f})" if iv_chg else "")
 
             # ── Gate: 3/4 required ────────────────────────────────────────────
             count = len(conditions)
@@ -292,6 +356,7 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
                 breach_signal=breach_signal,
                 volume_signal=volume_signal,
                 mode=mode_label,
+                triggers=triggers,
             )
             stock.set_analysis("NEUTRAL", "GAMMA_TRAP", result)
 
@@ -345,8 +410,12 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
 
             logger.debug(f"[RANGE_BOUND] {stock.stock_symbol} — start")
 
-            conditions:   list[str] = []
+            conditions:    list[str] = []
+            triggers:      dict[str, str] = {}
             iv_percentile: float | None = None
+            iv_trigger:    str | None = None
+            iv_hv_ratio:   float | None = None
+            iv_premium_pct: float | None = None
             put_wall_strike:  float | None = None
             call_wall_strike: float | None = None
             max_pain_dev:     float | None = None
@@ -363,6 +432,12 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
                         if cat in ("VERY_HIGH", "HIGH") or (ivp is not None and ivp > 70):
                             ivp_ok = True
                             iv_percentile = ivp
+                            iv_trigger = key
+                            atm_iv = getattr(i, "atm_iv", None)
+                            metric = f"IVP {ivp:.0f}th percentile ({cat})" if ivp else cat
+                            if atm_iv:
+                                metric += f" ATM IV {atm_iv:.1f}"
+                            triggers["R1 IV"] = metric
                             break
                 if ivp_ok:
                     break
@@ -372,8 +447,22 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
                 if iv_prem:
                     items = iv_prem if isinstance(iv_prem, list) else [iv_prem]
                     for i in items:
-                        if getattr(i, "zone", "") in ("EXPENSIVE", "EXTREME"):
+                        zone = getattr(i, "zone", "")
+                        if zone in ("EXPENSIVE", "EXTREME"):
                             ivp_ok = True
+                            iv_trigger = "IV_PREMIUM"
+                            iv_hv_ratio = getattr(i, "iv_hv_ratio", None)
+                            iv_premium_pct = getattr(i, "iv_premium_pct", None)
+                            atm_iv = getattr(i, "atm_iv", None)
+                            hv = getattr(i, "hv", None)
+                            metric = f"{zone}"
+                            if iv_hv_ratio:
+                                metric += f" IV/HV {iv_hv_ratio:.2f}x"
+                            if iv_premium_pct:
+                                metric += f" ({iv_premium_pct:.0f}% above HV)"
+                            if atm_iv and hv:
+                                metric += f" ATM IV {atm_iv:.1f} vs HV {hv:.1f}"
+                            triggers["R1 IV"] = metric
                             break
 
             if ivp_ok:
@@ -447,6 +536,9 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
             both_walls = has_floor and has_ceiling
             if both_walls:
                 conditions.append("CEILING_AND_FLOOR")
+                wall_metric = f"Put floor {put_wall_strike:.0f} / Call ceiling {call_wall_strike:.0f}" \
+                    if put_wall_strike and call_wall_strike else "both walls present"
+                triggers["R2 OI Walls"] = wall_metric
 
             logger.debug(
                 f"[RANGE_BOUND] {stock.stock_symbol} | R2 WALLS "
@@ -468,6 +560,7 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
             neutral_momentum = not vol_breakout_present and not rsi_div_present
             if neutral_momentum:
                 conditions.append("NEUTRAL_MOMENTUM")
+                triggers["R3 Momentum"] = "no volume breakout, no RSI divergence"
             logger.debug(
                 f"[RANGE_BOUND] {stock.stock_symbol} | R3 NEUTRAL_MOMENTUM={neutral_momentum} "
                 f"vol_breakout={vol_breakout_present} rsi_div={rsi_div_present}"
@@ -488,6 +581,7 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
             no_instit_push = not long_buildup_present and not short_buildup_present
             if no_instit_push:
                 conditions.append("NO_INSTIT_PUSH")
+                triggers["R4 Futures"] = "no long/short buildup detected"
             logger.debug(
                 f"[RANGE_BOUND] {stock.stock_symbol} | R4 NO_INSTIT_PUSH={no_instit_push} "
                 f"long_buildup={long_buildup_present} short_buildup={short_buildup_present}"
@@ -511,16 +605,41 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
                     break
             if mp_ok:
                 conditions.append("MAX_PAIN_MAGNET")
+                direction_word = "above" if (max_pain_dev or 0) > 0 else "below"
+                mp_metric = f"{abs(max_pain_dev):.1f}% {direction_word} max pain" if max_pain_dev is not None else "within gravity zone"
+                triggers["R5 MaxPain"] = mp_metric
             logger.debug(
                 f"[RANGE_BOUND] {stock.stock_symbol} | R5 MAX_PAIN_MAGNET={mp_ok} "
                 f"dev={max_pain_dev}"
             )
 
-            # ── Gate: 4/5 required ────────────────────────────────────────────
+            # ── R6: GEX Supports Range ────────────────────────────────────────
+            # Positive GEX (MODERATE or STRONG) means dealers are long gamma —
+            # they actively dampen moves, creating the ideal premium-selling environment.
+            gex_supports = False
+            gex_regime_data = self._get(stock, "NEUTRAL", "GEX_REGIME")
+            if gex_regime_data:
+                items = gex_regime_data if isinstance(gex_regime_data, list) else [gex_regime_data]
+                for g in items:
+                    if (getattr(g, "regime", "") == "POSITIVE"
+                            and getattr(g, "magnitude", "") in ("MODERATE", "STRONG")):
+                        gex_supports = True
+                        break
+            if gex_supports:
+                conditions.append("GEX_POSITIVE_REGIME")
+                gex_data = gex_regime_data if not isinstance(gex_regime_data, list) else gex_regime_data[0]
+                gex_total = getattr(gex_data, "gex_total", None)
+                gex_mag = getattr(gex_data, "magnitude", "")
+                triggers["R6 GEX"] = f"POSITIVE {gex_mag}" + (f" ({gex_total:+.0f} Cr)" if gex_total is not None else "")
+            logger.debug(
+                f"[RANGE_BOUND] {stock.stock_symbol} | R6 GEX_POSITIVE_REGIME={gex_supports}"
+            )
+
+            # ── Gate: 4/6 required (threshold unchanged, R6 adds confidence) ──
             count = len(conditions)
             logger.debug(
                 f"[RANGE_BOUND] {stock.stock_symbol} | "
-                f"conditions={count}/5 — {conditions}"
+                f"conditions={count}/6 — {conditions}"
             )
             if count < self.RANGE_BOUND_MIN_CONDITIONS:
                 return False
@@ -533,19 +652,24 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
                 conditions_met=count,
                 conditions_detail=conditions,
                 iv_percentile=iv_percentile,
+                iv_trigger=iv_trigger,
+                iv_hv_ratio=iv_hv_ratio,
+                iv_premium_pct=iv_premium_pct,
                 put_wall_strike=put_wall_strike,
                 call_wall_strike=call_wall_strike,
                 max_pain_dev_pct=max_pain_dev,
                 setup_type=setup_type,
                 mode=self._mode_label(),
+                gex_supports=gex_supports,
+                triggers=triggers,
             )
             stock.set_analysis("NEUTRAL", "RANGE_BOUND_SETUP", result)
             self._set_priority_override(stock, NotificationPriority.HIGH)
 
             logger.info(
                 f"[RANGE_BOUND] {stock.stock_symbol} — FIRED {setup_type} "
-                f"({count}/5) walls=[{put_wall_strike}, {call_wall_strike}] "
-                f"ivp={iv_percentile} mp_dev={max_pain_dev}"
+                f"({count}/6) walls=[{put_wall_strike}, {call_wall_strike}] "
+                f"ivp={iv_percentile} mp_dev={max_pain_dev} gex_supports={gex_supports}"
             )
             return True
 
@@ -729,6 +853,27 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
             )
 
             # ── All 3 conditions met ──────────────────────────────────────────
+            _candle_labels = {
+                "Double_candle_stick_pattern":    "Engulfing/Piercing",
+                "Single_candle_reversal_pattern": "Hammer/Shooting Star",
+                "Triple_candle_stick_pattern":    "Morning/Evening Star",
+                "Triple_candle_reversal_pattern": "Triple reversal",
+            }
+            _pcr_labels = {
+                "PCR_REVERSAL":       "PCR zone crossover",
+                "PCR_POS_REVERSAL":   "PCR 3-day reversal",
+                "PCR_INTRADAY_TREND": "PCR intraday trend",
+            }
+            ex_ivp = getattr(ex_item, "iv_percentile", None)
+            triggers = {
+                "S1 Exhaustion": f"{panic_direction} panic {exhaustion_conf} confidence"
+                    + (f" (IVP {ex_ivp:.0f}th)" if ex_ivp else ""),
+                "S2 SR Wall": f"OI wall {test_strike:.0f}, {proximity_pct:.2f}% away, "
+                    + _candle_labels.get(confirming_candle, confirming_candle),
+                "S3 PCR Trap": _pcr_labels.get(pcr_reversal_key, pcr_reversal_key)
+                    + f" in {fade_direction}",
+            }
+
             result = SKEW_FADE_SETUP_NT(
                 conditions_met=3,
                 fade_direction=fade_direction,
@@ -739,6 +884,7 @@ class OptionSellerCompositeAnalyser(BaseAnalyzer):
                 candle_key=confirming_candle,
                 pcr_signal=pcr_reversal_key,
                 mode=self._mode_label(),
+                triggers=triggers,
             )
             stock.set_analysis("NEUTRAL", "SKEW_FADE_SETUP", result)
             self._set_priority_override(stock, NotificationPriority.HIGH)

--- a/common/constants.py
+++ b/common/constants.py
@@ -20,6 +20,15 @@ ENV_OPTIONS_SOURCE      = "OPTIONS_SOURCE"         # "zerodha" (default) or "sen
 # SENSEX uses BFO segment on Zerodha (BSE derivatives); NIFTY/BANKNIFTY use NFO (NSE derivatives).
 LIVE_OPTIONS_INDICES = ["NIFTY", "BANKNIFTY", "SENSEX"]
 
+# Lot sizes per index for GEX computation (gamma × OI × lot_size × spot²/100).
+# Used by GEXAnalyser. Fallback = 1 (relative GEX, not absolute) for unknown symbols.
+INDEX_LOT_SIZES = {
+    "NIFTY":     75,
+    "BANKNIFTY": 15,
+    "SENSEX":    10,
+    "FINNIFTY":  40,
+}
+
 # Indices excluded from all analysis (fetch + orchestrator).
 # INDIA_VIX — volatility index, has no options chain; Sensibull API returns 500 for it.
 # FINNIFTY  — Sensibull insights API returns 500; low retail relevance.
@@ -34,6 +43,7 @@ ENV_NO_OF_STOCKS = "NO_OF_STOCKS"
 ENV_NO_OF_INDEX  = "NO_OF_INDEX"
 ENV_DEV_MAX_CYCLES = "DEV_MAX_CYCLES"        # Max intraday loop cycles in dev mode (0 = unlimited)
 ENV_DEV_LOOP_WAIT  = "DEV_LOOP_WAIT_TIME"    # Seconds to sleep between dev cycles (-1 = use production wait time)
+ENV_THREAD_POOL_WORKERS = "THREAD_POOL_WORKERS"  # Number of worker threads in the analysis pool (default: 20)
 
 
 #DEV_CONSTANTS
@@ -41,6 +51,10 @@ ENV_DEV_LOOP_WAIT  = "DEV_LOOP_WAIT_TIME"    # Seconds to sleep between dev cycl
 # in dev mode (e.g. NO_OF_STOCKS=5). -1 means no limit (all loaded).
 NO_OF_STOCKS = int(os.environ.get(ENV_NO_OF_STOCKS, -1))
 NO_OF_INDEX  = int(os.environ.get(ENV_NO_OF_INDEX,  -1))
+# Worker threads for the per-stock analysis ThreadPoolExecutor.
+# Optimal for I/O-bound workload (90% network wait): 20 on i5-6200U (4 hw-threads).
+# Raise to 32 for larger FnO universes; lower to 12 if Sensibull 429s are observed.
+THREAD_POOL_WORKERS = int(os.environ.get(ENV_THREAD_POOL_WORKERS, "20"))
 
 
 #INTRADAY CONSTANTS
@@ -177,6 +191,13 @@ ANALYSIS_WEIGHTS = {
     "SKEW_FADE_SETUP":   0,  # Directional credit spread — panic exhaustion at OI wall
     "GAMMA_TRAP":        0,  # Kill-switch — close short positions, directional breach
 
+    # GEX (Gamma Exposure) signals — GEXAnalyser
+    "GEX_REGIME":         0,   # Positive/negative gamma regime — informational (excluded from score)
+    "GEX_FLIP_PROXIMITY": 16,  # Spot near GEX zero-crossing — regime change imminent
+    "GEX_WALL":           15,  # Gamma concentration wall — sticky price level
+    "GEX_WALL_BREACH":    18,  # Wall broken + dealer GEX dropped — confirmed directional
+    "GEX_IMBALANCE":      13,  # CE/PE gamma dominance imbalance (>2.5x ratio)
+
     # Price Levels
     "52-week-high": 8,
     "52-week-low": 8,
@@ -228,6 +249,7 @@ TECHNICAL_ANALYSES = {"RSI", "MACD", "EMA_CROSSOVER",
                       "Triple_candle_continuation_pattern",
                       "SUPERTREND", "RSI_DIVERGENCE", "STOCHASTIC", "OBV", "PIVOT_POINTS"}
 OPTIONS_ANALYSES = {"MAX_PAIN", "MAX_PAIN_TREND", "MAX_PAIN_ALIGNMENT",
+                    "GEX_FLIP_PROXIMITY", "GEX_WALL", "GEX_WALL_BREACH", "GEX_IMBALANCE",
                     "PCR_EXTREME", "PCR_BIAS", "PCR_TREND", "PCR_INTRADAY_TREND",
                     "PCR_REVERSAL", "PCR_POS_REVERSAL", "PCR_DIVERGENCE",
                     "IV_SPIKE", "IV_TREND", "IV_RANK", "IV_RANK_EXTREME",
@@ -260,6 +282,9 @@ NEUTRAL_EXCLUDE_FROM_SCORE = {
     "SKEW_FADE_SETUP",
     "GAMMA_TRAP",
     "GAMMA_TRAP_ACTIVE",    # Boolean suppression flag written by Gamma Trap
+    # GEX regime is purely informational — the directional signals (GEX_WALL_BREACH,
+    # GEX_FLIP_PROXIMITY) score normally; regime context does not.
+    "GEX_REGIME",
 }
 
 # NEUTRAL signals that SHOULD contribute to score (informational but valuable)

--- a/fno/sensibull_fetcher.py
+++ b/fno/sensibull_fetcher.py
@@ -64,7 +64,7 @@ class SensibullFetcher:
             url = self._INSIGHTS_URL.format(symbol=encoded)
             logger.info(f"Fetching Sensibull data for {stock.stock_symbol} from {url}")
 
-            response = requests.get(url, timeout=10)
+            response = requests.get(url, timeout=(5, 10))  # (connect_timeout, read_timeout)
             response.raise_for_status()
             data = response.json()
 
@@ -187,7 +187,7 @@ class SensibullFetcher:
             logger.info(
                 f"Fetching Sensibull OI chain for {stock.stock_symbol} ({mode})"
             )
-            response = requests.post(self._OI_CHAIN_URL, json=request_body, timeout=15)
+            response = requests.post(self._OI_CHAIN_URL, json=request_body, timeout=(5, 15))  # (connect_timeout, read_timeout)
             response.raise_for_status()
             data = response.json()
 
@@ -285,7 +285,7 @@ class SensibullFetcher:
             url = self._IV_CHART_URL.format(symbol=encoded)
             logger.info(f"[IV_CHART] Fetching IV chart for {stock.stock_symbol} from {url}")
 
-            response = requests.get(url, timeout=15)
+            response = requests.get(url, timeout=(5, 15))  # (connect_timeout, read_timeout)
             response.raise_for_status()
             data = response.json()
 
@@ -442,7 +442,7 @@ class SensibullFetcher:
                 f"[OI_HISTORY] Fetching daily OI history for {stock.stock_symbol} "
                 f"(options_expiry={nearest_options_expiry} futures_expiry={futures_expiry})"
             )
-            response = requests.post(self._OI_HISTORY_URL, json=payload, timeout=20)
+            response = requests.post(self._OI_HISTORY_URL, json=payload, timeout=(5, 20))  # (connect_timeout, read_timeout)
             response.raise_for_status()
             data = response.json()
 

--- a/intraday/intraday_monitor.py
+++ b/intraday/intraday_monitor.py
@@ -21,6 +21,7 @@ from analyser.IVAnalyser import IVAnalyser
 from analyser.PCRAnalyser import PCRAnalyser
 from analyser.MaxPainAnalyser import MaxPainAnalyser
 from analyser.OIChainAnalyser import OIChainAnalyser
+from analyser.GEXAnalyser import GEXAnalyser
 from analyser.PanicModeAnalyser import PanicModeAnalyser
 from analyser.OptionSellerCompositeAnalyser import OptionSellerCompositeAnalyser
 from common.logging_util import logger
@@ -113,6 +114,7 @@ def _ping_healthcheck():
 # ═══════════════════════════════════════════════════════════════════════════
 
 _stale_alerts_sent = set()  # tracks symbols already alerted this session
+_stale_alerts_lock  = threading.Lock()  # guards check-then-add on _stale_alerts_sent
 
 def check_data_freshness(stock, stale_threshold_sec=120):
     """Check that live options data has been updated recently.
@@ -145,8 +147,8 @@ def check_data_freshness(stock, stale_threshold_sec=120):
         return True  # no options tracking for this stock — nothing to check
 
     last_updated = options_agg.get("last_updated")
-    if last_updated is None:
-        return True  # field not populated yet
+    if not last_updated:
+        return True  # field not populated yet (0.0 = never written)
 
     if isinstance(last_updated, (int, float)):
         age = now.timestamp() - last_updated
@@ -158,19 +160,22 @@ def check_data_freshness(stock, stale_threshold_sec=120):
 
     if age > stale_threshold_sec:
         symbol = getattr(stock, "stock_symbol", "UNKNOWN")
-        if symbol not in _stale_alerts_sent:
+        with _stale_alerts_lock:
+            if symbol in _stale_alerts_sent:
+                return False
             _stale_alerts_sent.add(symbol)
-            msg = (
-                f"⚠️ <b>STALE DATA — {symbol}</b>\n\n"
-                f"options_aggregate last updated <b>{int(age)}s ago</b> "
-                f"(threshold: {stale_threshold_sec}s).\n"
-                f"WebSocket may have dropped silently."
-            )
-            try:
-                TELEGRAM_NOTIFICATIONS.send_notification(msg, parse_mode="HTML")
-            except Exception:
-                pass
-            logger.warning(f"Stale data detected for {symbol}: {int(age)}s old")
+        # Build and send the alert outside the lock so we never hold a lock over I/O
+        msg = (
+            f"⚠️ <b>STALE DATA — {symbol}</b>\n\n"
+            f"options_aggregate last updated <b>{int(age)}s ago</b> "
+            f"(threshold: {stale_threshold_sec}s).\n"
+            f"WebSocket may have dropped silently."
+        )
+        try:
+            TELEGRAM_NOTIFICATIONS.send_notification(msg, parse_mode="HTML")
+        except Exception:
+            pass
+        logger.warning(f"Stale data detected for {symbol}: {int(age)}s old")
         return False
 
     return True
@@ -181,7 +186,7 @@ class Trend (Enum):
     NEUTRAL = "NEUTRAL"
 
 
-thread_pool = None
+thread_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None  # initialised in init()
 orchestrator : AnalyserOrchestrator =  None
 PRODUCTION = False
 DEV_NOTIFY = False      # True = send Telegram alerts even in dev mode (DEV_NOTIFY=1)
@@ -740,39 +745,57 @@ def fetch_and_analyze_stocks() -> List[Tuple[MonitorResult, bool, Optional[str]]
     # Previously split across index/stock blocks causing a double reset per cycle.
     orchestrator.reset_all_constants()
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-        # Fetch price data for all stocks at once
-        price_future = executor.submit(fetch_price_data, stock_objs, index_objs, commodity_objs, global_indices_objs)
+    # ── Price data ────────────────────────────────────────────────────────────
+    # Single bulk yfinance download for all symbols; submitted to the pool so
+    # the main thread is not blocked, and a hard 60s timeout prevents a stalled
+    # yfinance connection from hanging the entire cycle.
+    price_future = thread_pool.submit(
+        fetch_price_data, stock_objs, index_objs, commodity_objs, global_indices_objs
+    )
+    try:
+        price_future.result(timeout=60)
+    except concurrent.futures.TimeoutError:
+        logger.error(
+            "Price data fetch timed out after 60s — proceeding with stale "
+            "priceData from last cycle"
+        )
+    except Exception as exc:
+        logger.error(f"Error fetching price data for stocks: {exc}")
+        return [(MonitorResult.ERROR, False, str(exc))]
 
-        # Wait for price data fetching to complete
+    # ── Per-stock analysis ────────────────────────────────────────────────────
+    results: List[Tuple[MonitorResult, bool, Optional[str]]] = []
+
+    def _collect(monitor_futures: dict, label: str) -> None:
+        """Drain futures with a 90s hard timeout; cancel and skip stragglers."""
         try:
-            price_future.result()
-        except Exception as exc:
-            logger.error(f"Error fetching price data for stocks: {exc}")
-            return [(MonitorResult.ERROR, False, str(exc))]
+            for future in concurrent.futures.as_completed(monitor_futures, timeout=90):
+                item = monitor_futures[future]
+                try:
+                    results.append(future.result())
+                except Exception as exc:
+                    logger.error(f"Unexpected error processing {item.stockName}: {exc}")
+                    results.append((MonitorResult.ERROR, False, str(exc)))
+        except concurrent.futures.TimeoutError:
+            for future, item in monitor_futures.items():
+                if not future.done():
+                    future.cancel()
+                    logger.warning(
+                        f"[{label}] Analysis timed out for {item.stockName} — skipping"
+                    )
+                    results.append((MonitorResult.ERROR, False, "timeout"))
 
-        # Monitor and analyze all indices
-        results = []
-        monitor_futures = {executor.submit(process_stock, index): index for index in index_objs}
-        for future in concurrent.futures.as_completed(monitor_futures):
-            index = monitor_futures[future]
-            try:
-                result = future.result()
-                results.append(result)
-            except Exception as exc:
-                logger.error(f"Unexpected error processing {index.stockName}: {exc}")
-                results.append((MonitorResult.ERROR, False, str(exc)))
+    # Monitor and analyze all indices
+    _collect(
+        {thread_pool.submit(process_stock, index): index for index in index_objs},
+        "indices",
+    )
 
-        # Monitor and analyze all stocks
-        monitor_futures = {executor.submit(process_stock, stock): stock for stock in stock_objs}
-        for future in concurrent.futures.as_completed(monitor_futures):
-            stock = monitor_futures[future]
-            try:
-                result = future.result()
-                results.append(result)
-            except Exception as exc:
-                logger.error(f"Unexpected error processing {stock.stockName}: {exc}")
-                results.append((MonitorResult.ERROR, False, str(exc)))
+    # Monitor and analyze all stocks
+    _collect(
+        {thread_pool.submit(process_stock, stock): stock for stock in stock_objs},
+        "stocks",
+    )
 
     logger.info("Data fetching and analysis completed for all stocks")
     return results
@@ -1392,8 +1415,7 @@ def live_options_analysis():
                     _enrichment_only = (shared.app_ctx.options_source == "both")
                     _start_sensibull_feed(tm.live_options_engine, enrichment_only=_enrichment_only)
                 else:
-                    from notification.bot_listener import _subscribe_registered_options
-                    _subscribe_registered_options(tm)
+                    tm.subscribe_live_options(wait_for_ticks=True)
             else:
                 logger.error("WebSocket connect failed — live options analysis aborted")
                 return
@@ -1446,6 +1468,7 @@ def intraday_analysis(loop = True, loop_wait_time = 30, max_cycles = 0):
 
     is_in_time_period = isNowInTimePeriod(time(9,15), time(15,30), datetime.now().time())
     cycle = 0
+    _live_options_subscribed = False  # guard: subscribe option tokens once after first tick
 
     while(is_in_time_period or not PRODUCTION):
         cycle += 1
@@ -1459,6 +1482,19 @@ def intraday_analysis(loop = True, loop_wait_time = 30, max_cycles = 0):
             process_monitor_results(results)
         except Exception as e:
             logger.error(f"Critical error in stock analysis: {e}")
+
+        # After the first cycle, spot prices are available — subscribe Zerodha option tokens.
+        # Runs once only; skipped if already subscribed or if Zerodha WS is not connected.
+        if (not _live_options_subscribed
+                and ENABLE_LIVE_OPTIONS
+                and _options_source in ("zerodha", "both")):
+            tm = shared.app_ctx.zd_ticker_manager
+            if tm and tm.connected:
+                logger.info("[intraday] subscribing Zerodha option tokens after first cycle")
+                tm.subscribe_live_options(wait_for_ticks=False)
+                _live_options_subscribed = True
+            else:
+                logger.debug("[intraday] Zerodha WS not connected — option subscription deferred")
 
         report_top_gainers_and_losers()
         report_index_data()
@@ -1707,16 +1743,17 @@ def init():
         update_zerodha_option_chain(args.stock, args.index)
     orchestrator = AnalyserOrchestrator()
     if not LIVE_OPTIONS_ONLY:
-        orchestrator.register(VolumeAnalyser())
-        orchestrator.register(TechnicalAnalyser())
-        orchestrator.register(CandleStickAnalyser())
-        orchestrator.register(IVAnalyser())
-        orchestrator.register(FuturesAnalyser())
-        orchestrator.register(PCRAnalyser())
-        orchestrator.register(MaxPainAnalyser())
-        orchestrator.register(OIChainAnalyser())
-        orchestrator.register(PanicModeAnalyser())
-        orchestrator.register(OptionSellerCompositeAnalyser())  # MUST be last -- reads PANIC_EXHAUSTION
+        # orchestrator.register(VolumeAnalyser())
+        # orchestrator.register(TechnicalAnalyser())
+        # orchestrator.register(CandleStickAnalyser())
+        # orchestrator.register(IVAnalyser())
+        # orchestrator.register(FuturesAnalyser())
+        # orchestrator.register(PCRAnalyser())
+        # orchestrator.register(MaxPainAnalyser())
+        # orchestrator.register(OIChainAnalyser())
+        orchestrator.register(GEXAnalyser())        # After OIChainAnalyser; before composite
+        # orchestrator.register(PanicModeAnalyser())
+        # orchestrator.register(OptionSellerCompositeAnalyser())  # MUST be last -- reads PANIC_EXHAUSTION
     if ENABLE_ZERODHA_API:
         logger.info("Zerodha API enabled")
         userName = os.getenv(constant.ENV_ZERODHA_USERNAME)
@@ -1743,6 +1780,34 @@ def init():
         if LIVE_OPTIONS_ONLY:
             shared.app_ctx.zd_ticker_manager.index_only_mode = True
             logger.info("index_only_mode enabled — equity stocks excluded from WebSocket")
+
+        # Auto-connect Zerodha WebSocket using enctoken from .env.
+        # The auth service (stockanalysis-auth.service) writes a fresh enctoken
+        # before this process starts, so no Telegram bot interaction is needed.
+        # Skipped when OPTIONS_SOURCE=sensibull (Zerodha WS handles only equity/index ticks there).
+        if ENABLE_LIVE_OPTIONS and shared.app_ctx.options_source in ("zerodha", "both"):
+            enc_raw = os.getenv(constant.ENV_ZERODHA_ENC_TOKEN, "")
+            if enc_raw:
+                logger.info("[init] Auto-connecting Zerodha WebSocket using enctoken from .env")
+                shared.app_ctx.zd_ticker_manager.update_enctoken(quote(enc_raw, safe=""))
+                if shared.app_ctx.zd_ticker_manager.connect():
+                    logger.info("[init] Zerodha WebSocket connected successfully")
+                else:
+                    logger.warning(
+                        "[init] Zerodha WebSocket auto-connect failed — "
+                        "option ticks unavailable; use /enctoken via Telegram bot to retry"
+                    )
+            else:
+                logger.warning("[init] ZERODHA_ENC_TOKEN not set — Zerodha WebSocket not connected")
+
+    # Module-level thread pool — created once, reused every 310s cycle.
+    # Avoids 20× thread-creation overhead per cycle; workers park in the OS
+    # scheduler between submissions rather than being destroyed and rebuilt.
+    thread_pool = concurrent.futures.ThreadPoolExecutor(
+        max_workers=constant.THREAD_POOL_WORKERS,
+        thread_name_prefix="monitor",
+    )
+    logger.info(f"Thread pool initialised with {constant.THREAD_POOL_WORKERS} workers")
 
 
 def parse_arguments():
@@ -1860,6 +1925,15 @@ def _shutdown_background_services():
     ThreadPoolExecutor workers are non-daemon by default and will block exit indefinitely
     if not explicitly stopped.
     """
+    global thread_pool
+    if thread_pool is not None:
+        try:
+            thread_pool.shutdown(wait=False, cancel_futures=True)
+            logger.debug("[shutdown] analysis thread pool stopped")
+        except Exception as e:
+            logger.warning(f"[shutdown] thread pool shutdown error: {e}")
+        thread_pool = None  # type: ignore[assignment]
+
     narrator = shared.app_ctx.narrator
     if narrator:
         try:

--- a/notification/commands/account.py
+++ b/notification/commands/account.py
@@ -1,7 +1,6 @@
 """Account & connection commands: /start, /enctoken."""
 from __future__ import annotations
 
-import time
 import urllib.parse
 import os
 
@@ -38,62 +37,8 @@ def _update_enctoken_in_env(new_enctoken: str) -> None:
 
 
 def _subscribe_registered_options(ticker_manager) -> None:
-    """After WebSocket connects, subscribe to option tokens for LIVE_OPTIONS_INDICES only."""
-    registry = shared.app_ctx.token_registry
-    if registry is None:
-        return
-
-    from common.token_registry import TokenType, OptionZone
-    from common.constants import LIVE_OPTIONS_INDICES
-    from notification.Notification import TELEGRAM_NOTIFICATIONS
-
-    # Wait briefly for the first index ticks to arrive with spot prices
-    time.sleep(2)
-
-    total_option_tokens = 0
-    option_lines = []
-
-    for token, index_obj in shared.app_ctx.index_token_obj_dict.items():
-        symbol = index_obj.stock_symbol
-
-        if symbol not in LIVE_OPTIONS_INDICES:
-            continue
-
-        option_tokens = registry.get_tokens_by_type(symbol, TokenType.OPTION)
-        if not option_tokens:
-            continue
-
-        spot = index_obj.zerodha_data.get("last_price") or index_obj.ltp
-        if not spot or spot <= 0:
-            logger.warning(f"No spot price for {symbol}, skipping option subscription")
-            continue
-
-        ticker_manager.subscribe_options_for_symbol(symbol, spot)
-        logger.info(f"Option subscription initiated for {symbol} at spot {spot}")
-
-        subscribed_count = sum(
-            len(registry.get_option_tokens_by_zone(symbol, zone))
-            for zone in OptionZone
-        )
-        total_option_tokens += subscribed_count
-        option_lines.append(f"  {symbol}: {subscribed_count} tokens (spot {spot:.0f})")
-
-    index_count = len(shared.app_ctx.index_token_obj_dict)
-    equity_count = len(shared.app_ctx.stock_token_obj_dict)
-    base_count = index_count + (0 if ticker_manager.index_only_mode else equity_count)
-    total = base_count + total_option_tokens
-
-    mode_note = "index-only" if ticker_manager.index_only_mode else f"{equity_count} equity + {index_count} index"
-    lines = [
-        "WebSocket connected",
-        f"Base: {base_count} ({mode_note})",
-        f"Options: {total_option_tokens}",
-    ]
-    lines.extend(option_lines)
-    lines.append(f"Total: {total} / 500")
-
-    TELEGRAM_NOTIFICATIONS.send_notification("\n".join(lines))
-    logger.info(f"WebSocket subscription summary — total {total} tokens")
+    """Delegate to ZerodhaTickerManager.subscribe_live_options() (canonical implementation)."""
+    ticker_manager.subscribe_live_options(wait_for_ticks=True)
 
 
 # ─── Handlers ────────────────────────────────────────────────────────────────

--- a/tests/analyser/test_gex_analyser.py
+++ b/tests/analyser/test_gex_analyser.py
@@ -1,0 +1,430 @@
+"""Tests for analyser/GEXAnalyser.py."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+import common.shared as shared
+from analyser.GEXAnalyser import GEXAnalyser
+from tests.analyser.conftest import make_stock, patch_ctx
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _make_options_live(spot=24000.0, ce_gamma=0.002, pe_gamma=0.002,
+                       ce_oi=100_000, pe_oi=80_000, strikes=None):
+    """
+    Build a minimal options_live dict.
+    Default: 5 strikes centred on spot, CE gamma slightly > PE gamma
+    (positive GEX = dealers long gamma = market pins).
+    """
+    if strikes is not None:
+        return strikes
+
+    step = 100  # NIFTY-style 100pt strikes
+    base = int(spot / step) * step
+    result = {}
+    for i in range(-2, 3):
+        s = float(base + i * step)
+        result[s] = {
+            "CE": {"gamma": ce_gamma, "oi": ce_oi, "ltp": 100.0},
+            "PE": {"gamma": pe_gamma, "oi": pe_oi, "ltp": 80.0},
+        }
+    return result
+
+
+def _stock_with_gamma(symbol="NIFTY", spot=24000.0,
+                      ce_gamma=0.002, pe_gamma=0.002,
+                      ce_oi=100_000, pe_oi=80_000,
+                      prev_regime=None, strikes=None):
+    s = make_stock(symbol=symbol)
+    s.ltp = spot
+    s._tick_store.options_live = _make_options_live(spot, ce_gamma, pe_gamma, ce_oi, pe_oi, strikes)
+    if prev_regime:
+        s.options_aggregate["gex_regime"] = prev_regime
+    return s
+
+
+# ── Gate tests ─────────────────────────────────────────────────────────────────
+
+class TestGates:
+    def test_non_index_symbol_skipped(self, intraday_ctx):
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = make_stock(symbol="RELIANCE")
+        s._tick_store.options_live = _make_options_live()
+        assert a.analyse_gex_regime(s) is False
+
+    def test_no_options_live_skipped(self, intraday_ctx):
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = make_stock(symbol="NIFTY")
+        s._tick_store.options_live = {}
+        assert a.analyse_gex_regime(s) is False
+
+    def test_all_zero_gamma_skipped(self, intraday_ctx):
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = make_stock(symbol="NIFTY")
+        s._tick_store.options_live = {
+            24000.0: {"CE": {"gamma": 0.0, "oi": 50000}, "PE": {"gamma": 0.0, "oi": 50000}}
+        }
+        assert a.analyse_gex_regime(s) is False
+
+
+# ── GEX_REGIME ─────────────────────────────────────────────────────────────────
+
+class TestGexRegime:
+    def test_positive_regime_when_ce_dominates(self, intraday_ctx):
+        """CE gamma × OI > PE gamma × OI → positive GEX → dealers long gamma."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        # CE: gamma=0.003, OI=100k  →  CE contribution >> PE contribution
+        s = _stock_with_gamma("NIFTY", spot=24000.0, ce_gamma=0.003, pe_gamma=0.001,
+                               ce_oi=100_000, pe_oi=100_000)
+        result = a.analyse_gex_regime(s)
+        assert result is True
+        regime_data = s.analysis["NEUTRAL"]["GEX_REGIME"]
+        assert regime_data.regime == "POSITIVE"
+        assert regime_data.gex_total > 0
+
+    def test_negative_regime_when_pe_dominates(self, intraday_ctx):
+        """PE gamma × OI > CE gamma × OI → negative GEX → dealers short gamma."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = _stock_with_gamma("NIFTY", spot=24000.0, ce_gamma=0.001, pe_gamma=0.003,
+                               ce_oi=100_000, pe_oi=100_000)
+        a.analyse_gex_regime(s)
+        regime_data = s.analysis["NEUTRAL"]["GEX_REGIME"]
+        assert regime_data.regime == "NEGATIVE"
+        assert regime_data.gex_total < 0
+
+    def test_regime_flip_detected(self, intraday_ctx):
+        """When prev_regime=POSITIVE and new regime=NEGATIVE, regime_flipped=True."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = _stock_with_gamma("NIFTY", spot=24000.0, ce_gamma=0.001, pe_gamma=0.003,
+                               ce_oi=100_000, pe_oi=100_000, prev_regime="POSITIVE")
+        a.analyse_gex_regime(s)
+        regime_data = s.analysis["NEUTRAL"]["GEX_REGIME"]
+        assert regime_data.regime_flipped is True
+        assert regime_data.prev_regime == "POSITIVE"
+
+    def test_no_flip_when_regime_unchanged(self, intraday_ctx):
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = _stock_with_gamma("NIFTY", spot=24000.0, ce_gamma=0.003, pe_gamma=0.001,
+                               ce_oi=100_000, pe_oi=100_000, prev_regime="POSITIVE")
+        a.analyse_gex_regime(s)
+        regime_data = s.analysis["NEUTRAL"]["GEX_REGIME"]
+        assert regime_data.regime_flipped is False
+
+    def test_options_aggregate_updated(self, intraday_ctx):
+        """analyse_gex_regime must persist results to options_aggregate."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = _stock_with_gamma("NIFTY", spot=24000.0, ce_gamma=0.003, pe_gamma=0.001,
+                               ce_oi=100_000, pe_oi=100_000)
+        a.analyse_gex_regime(s)
+        agg = s.options_aggregate
+        assert agg["gex_total"] != 0.0
+        assert agg["gex_regime"] in ("POSITIVE", "NEGATIVE")
+        assert isinstance(agg["gex_by_strike"], dict)
+        assert len(agg["gex_by_strike"]) > 0
+
+    def test_magnitude_mild(self, intraday_ctx):
+        """Very small gamma → MILD magnitude."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        # Tiny gamma → tiny GEX total < 500 Cr
+        s = _stock_with_gamma("NIFTY", spot=24000.0, ce_gamma=0.00001, pe_gamma=0.000005,
+                               ce_oi=1000, pe_oi=1000)
+        a.analyse_gex_regime(s)
+        regime_data = s.analysis["NEUTRAL"]["GEX_REGIME"]
+        assert regime_data.magnitude == "MILD"
+
+    def test_banknifty_uses_correct_lot_size(self, intraday_ctx):
+        """BANKNIFTY lot_size=15 should produce smaller GEX than NIFTY lot_size=75."""
+        a = GEXAnalyser()
+        a.reset_constants()
+
+        def _run(symbol, lot):
+            s = _stock_with_gamma(symbol, spot=52000.0, ce_gamma=0.002, pe_gamma=0.001,
+                                   ce_oi=100_000, pe_oi=100_000)
+            a.analyse_gex_regime(s)
+            return s.options_aggregate["gex_total"]
+
+        nifty_gex = _run("NIFTY", 75)
+        banknifty_gex = _run("BANKNIFTY", 15)
+        # NIFTY lot (75) is 5× BANKNIFTY lot (15) — GEX should reflect that
+        assert nifty_gex > banknifty_gex
+
+
+# ── GEX_FLIP_PROXIMITY ─────────────────────────────────────────────────────────
+
+class TestGexFlipProximity:
+    def _stock_with_flip_level(self, flip_level, spot, gex_total=1500.0):
+        s = make_stock(symbol="NIFTY")
+        s.ltp = spot
+        s._tick_store.options_live = _make_options_live(spot=spot, ce_gamma=0.002, pe_gamma=0.001)
+        s.options_aggregate["gex_flip_level"] = flip_level
+        s.options_aggregate["gex_total"]      = gex_total
+        return s
+
+    def test_fires_when_spot_within_threshold(self, intraday_ctx):
+        a = GEXAnalyser()
+        a.reset_constants()
+        # spot = 24000, flip = 24080 → distance = 0.33% < 0.4% threshold
+        s = self._stock_with_flip_level(flip_level=24080.0, spot=24000.0)
+        result = a.analyse_gex_flip_proximity(s)
+        assert result is True
+        data = s.analysis["NEUTRAL"]["GEX_FLIP_PROXIMITY"]
+        assert data.approaching_from == "BELOW"
+        assert data.distance_pct < 0.4
+
+    def test_does_not_fire_when_far(self, intraday_ctx):
+        a = GEXAnalyser()
+        a.reset_constants()
+        # spot = 24000, flip = 24500 → distance = 2.08% > 0.4%
+        s = self._stock_with_flip_level(flip_level=24500.0, spot=24000.0)
+        result = a.analyse_gex_flip_proximity(s)
+        assert result is False
+
+    def test_approaching_from_above(self, intraday_ctx):
+        a = GEXAnalyser()
+        a.reset_constants()
+        # spot above flip level
+        s = self._stock_with_flip_level(flip_level=24000.0, spot=24080.0)
+        a.analyse_gex_flip_proximity(s)
+        data = s.analysis["NEUTRAL"]["GEX_FLIP_PROXIMITY"]
+        assert data.approaching_from == "ABOVE"
+
+    def test_skipped_when_gex_below_noise_floor(self, intraday_ctx):
+        a = GEXAnalyser()
+        a.reset_constants()
+        # Small GEX → below noise floor → skip
+        s = self._stock_with_flip_level(flip_level=24050.0, spot=24000.0, gex_total=50.0)
+        result = a.analyse_gex_flip_proximity(s)
+        assert result is False
+
+    def test_wider_threshold_in_positional_mode(self, positional_ctx):
+        """Positional mode uses 0.6% threshold — should fire at 0.5% distance."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        # 0.5% distance: spot=24000, flip=24120 → 0.5% → fires at 0.6, not at 0.4
+        s = self._stock_with_flip_level(flip_level=24120.0, spot=24000.0, gex_total=1500.0)
+        result = a.analyse_gex_flip_proximity(s)
+        assert result is True
+
+
+# ── GEX_WALL ───────────────────────────────────────────────────────────────────
+
+class TestGexWall:
+    def _stock_with_gex_by_strike(self, spot=24000.0, gex_by_strike=None):
+        s = make_stock(symbol="NIFTY")
+        s.ltp = spot
+        # Need options_live with gamma so _is_applicable passes
+        s._tick_store.options_live = _make_options_live(spot=spot)
+        if gex_by_strike:
+            s.options_aggregate["gex_by_strike"] = gex_by_strike
+        return s
+
+    def test_call_wall_detected_in_bearish_bucket(self, intraday_ctx):
+        """A spike in CE GEX at one strike → call wall → BEARISH bucket."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        # Normal GEX ~1.0 at most strikes, huge spike at 24200
+        gex = {23800.0: 1.0, 23900.0: 1.2, 24000.0: 1.1,
+               24100.0: 1.0, 24200.0: 600.0}  # spike
+        s = self._stock_with_gex_by_strike(spot=24000.0, gex_by_strike=gex)
+        result = a.analyse_gex_wall(s)
+        assert result is True
+        assert "GEX_WALL" in s.analysis.get("BEARISH", {})
+
+    def test_put_wall_detected_in_bullish_bucket(self, intraday_ctx):
+        """A negative GEX spike (PE dominates) → put wall → BULLISH bucket."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        gex = {23800.0: -600.0, 23900.0: -1.0, 24000.0: -1.0,
+               24100.0: -1.0, 24200.0: -1.0}  # spike on downside
+        s = self._stock_with_gex_by_strike(spot=24000.0, gex_by_strike=gex)
+        result = a.analyse_gex_wall(s)
+        assert result is True
+        assert "GEX_WALL" in s.analysis.get("BULLISH", {})
+
+    def test_no_wall_when_distribution_is_flat(self, intraday_ctx):
+        """When all strikes have similar GEX, no wall should fire."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        gex = {float(s): 100.0 for s in range(23800, 24300, 100)}
+        s = self._stock_with_gex_by_strike(spot=24000.0, gex_by_strike=gex)
+        result = a.analyse_gex_wall(s)
+        assert result is False
+
+    def test_wall_outside_5pct_ignored(self, intraday_ctx):
+        """Spikes beyond ±5% of spot are not counted as walls."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        # Spike at 20000 — far from spot 24000 (>16% away)
+        gex = {23800.0: 1.0, 23900.0: 1.0, 24000.0: 1.0,
+               24100.0: 1.0, 20000.0: 999.0}
+        s = self._stock_with_gex_by_strike(spot=24000.0, gex_by_strike=gex)
+        result = a.analyse_gex_wall(s)
+        assert result is False
+
+
+# ── GEX_WALL_BREACH ────────────────────────────────────────────────────────────
+
+class TestGexWallBreach:
+    def test_call_wall_breach_emits_bullish(self, intraday_ctx):
+        """Spot crossed a call wall (CE dominated) AND GEX dropped ≥30%."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = make_stock(symbol="NIFTY")
+        spot = 24300.0
+        s.ltp = spot
+        s._tick_store.options_live = _make_options_live(spot=spot)
+
+        # Previous cycle: call wall at 24200 (CE dominated, high GEX)
+        prev_gex = {23800.0: 1.0, 23900.0: 1.2, 24000.0: 1.1,
+                    24100.0: 1.3, 24200.0: 500.0}
+        # Current cycle: spot crossed 24200, GEX at 24200 dropped 60%
+        curr_gex = {23800.0: 1.0, 23900.0: 1.2, 24000.0: 1.1,
+                    24100.0: 1.3, 24200.0: 200.0}
+        s.options_aggregate["gex_by_strike"] = curr_gex
+
+        # Seed previous cycle state into analyser
+        a._prev_gex_by_strike = {"NIFTY": prev_gex}
+
+        result = a.analyse_gex_wall_breach(s)
+        assert result is True
+        assert "GEX_WALL_BREACH" in s.analysis.get("BULLISH", {})
+        breach = s.analysis["BULLISH"]["GEX_WALL_BREACH"]
+        assert breach.breach_side == "CALL"
+        assert breach.gex_drop_pct >= 30.0
+
+    def test_no_breach_when_gex_held(self, intraday_ctx):
+        """If GEX at the wall strike didn't drop, dealers still defending — no breach."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = make_stock(symbol="NIFTY")
+        s._ltp = 24250.0
+        s._tick_store.options_live = _make_options_live(spot=24250.0)
+
+        prev_gex = {24200.0: 500.0}
+        curr_gex = {24200.0: 490.0}  # only 2% drop — not a breach
+        s.options_aggregate["gex_by_strike"] = curr_gex
+        a._prev_gex_by_strike = {"NIFTY": prev_gex}
+
+        result = a.analyse_gex_wall_breach(s)
+        assert result is False
+
+    def test_no_breach_on_first_cycle(self, intraday_ctx):
+        """First run has no previous cycle data — should return False silently."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = make_stock(symbol="NIFTY")
+        s._ltp = 24000.0
+        s._tick_store.options_live = _make_options_live()
+        s.options_aggregate["gex_by_strike"] = {24000.0: 100.0}
+        # No _prev_gex_by_strike set
+        result = a.analyse_gex_wall_breach(s)
+        assert result is False
+
+    def test_wall_breach_not_available_in_positional(self, positional_ctx):
+        """GEX_WALL_BREACH is intraday-only — positional run should not fire it."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = make_stock(symbol="NIFTY")
+        s._ltp = 24250.0
+        s._tick_store.options_live = _make_options_live(spot=24250.0)
+        s.options_aggregate["gex_by_strike"] = {24200.0: 200.0}
+        a._prev_gex_by_strike = {"NIFTY": {24200.0: 500.0}}
+        # Positional methods don't include analyse_gex_wall_breach
+        assert not any(m.__name__ == "analyse_gex_wall_breach"
+                       for m in a._positional_methods)
+
+
+# ── GEX_IMBALANCE ──────────────────────────────────────────────────────────────
+
+class TestGexImbalance:
+    def _stock_with_gex_sides(self, gex_ce, gex_pe, symbol="NIFTY"):
+        s = make_stock(symbol=symbol)
+        s._ltp = 24000.0
+        s._tick_store.options_live = _make_options_live()
+        s.options_aggregate["gex_ce"] = gex_ce
+        s.options_aggregate["gex_pe"] = gex_pe
+        return s
+
+    def test_ce_dominance_emits_bearish(self, intraday_ctx):
+        """CE GEX 3× PE GEX → CE dominant → BEARISH bucket."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = self._stock_with_gex_sides(gex_ce=600.0, gex_pe=200.0)
+        result = a.analyse_gex_imbalance(s)
+        assert result is True
+        assert "GEX_IMBALANCE" in s.analysis.get("BEARISH", {})
+        data = s.analysis["BEARISH"]["GEX_IMBALANCE"]
+        assert data.dominant_side == "CE"
+        assert data.imbalance_ratio == pytest.approx(3.0, rel=0.01)
+
+    def test_pe_dominance_emits_bullish(self, intraday_ctx):
+        """PE GEX 4× CE GEX → PE dominant → BULLISH bucket."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = self._stock_with_gex_sides(gex_ce=150.0, gex_pe=600.0)
+        result = a.analyse_gex_imbalance(s)
+        assert result is True
+        assert "GEX_IMBALANCE" in s.analysis.get("BULLISH", {})
+        data = s.analysis["BULLISH"]["GEX_IMBALANCE"]
+        assert data.dominant_side == "PE"
+
+    def test_balanced_gex_no_signal(self, intraday_ctx):
+        """Equal CE and PE GEX → no imbalance → False."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = self._stock_with_gex_sides(gex_ce=300.0, gex_pe=300.0)
+        result = a.analyse_gex_imbalance(s)
+        assert result is False
+
+    def test_magnitude_extreme(self, intraday_ctx):
+        """CE/PE ratio > 6 → EXTREME magnitude."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = self._stock_with_gex_sides(gex_ce=700.0, gex_pe=100.0)
+        a.analyse_gex_imbalance(s)
+        data = s.analysis["BEARISH"]["GEX_IMBALANCE"]
+        assert data.magnitude == "EXTREME"
+
+    def test_magnitude_strong(self, intraday_ctx):
+        """Ratio between 4–6 → STRONG."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = self._stock_with_gex_sides(gex_ce=500.0, gex_pe=100.0)
+        a.analyse_gex_imbalance(s)
+        data = s.analysis["BEARISH"]["GEX_IMBALANCE"]
+        assert data.magnitude == "STRONG"
+
+    def test_skipped_when_one_side_below_noise_floor(self, intraday_ctx):
+        """If either side is below IMBALANCE_MIN_SIDE_CR, skip to avoid noise."""
+        a = GEXAnalyser()
+        a.reset_constants()
+        s = self._stock_with_gex_sides(gex_ce=500.0, gex_pe=5.0)  # pe too small
+        result = a.analyse_gex_imbalance(s)
+        assert result is False
+
+
+# ── reset_constants ────────────────────────────────────────────────────────────
+
+class TestResetConstants:
+    def test_intraday_thresholds(self, intraday_ctx):
+        a = GEXAnalyser()
+        a.reset_constants()
+        assert GEXAnalyser.FLIP_PROXIMITY_THRESHOLD_PCT == 0.4
+        assert GEXAnalyser.WALL_SIGMA == 1.5
+        assert GEXAnalyser.WALL_MIN_GEX_CR == 100
+
+    def test_positional_thresholds(self, positional_ctx):
+        a = GEXAnalyser()
+        a.reset_constants()
+        assert GEXAnalyser.FLIP_PROXIMITY_THRESHOLD_PCT == 0.6
+        assert GEXAnalyser.WALL_SIGMA == 1.8
+        assert GEXAnalyser.WALL_MIN_GEX_CR == 200

--- a/zerodha/tick_store.py
+++ b/zerodha/tick_store.py
@@ -64,6 +64,14 @@ class TickStore:
             "atm_ivp_type": None,
             "max_pain_strike": None,
             "future_price": 0.0,
+            # GEX (Gamma Exposure) — computed by GEXAnalyser every 5-min cycle.
+            # Requires gamma from Sensibull; stays 0.0 in Zerodha-only mode.
+            "gex_total": 0.0,       # Net GEX in ₹ crores (CE - PE)
+            "gex_ce": 0.0,          # CE-side GEX contribution
+            "gex_pe": 0.0,          # PE-side GEX contribution
+            "gex_regime": None,     # "POSITIVE" | "NEGATIVE" | None (not yet computed)
+            "gex_flip_level": None, # Strike where cumulative GEX crosses zero
+            "gex_by_strike": {},    # {strike: net_gex} — used by GEX_WALL_BREACH next cycle
         }
 
         # Live futures tick data from WebSocket

--- a/zerodha/zerodha_analysis.py
+++ b/zerodha/zerodha_analysis.py
@@ -239,6 +239,15 @@ class ZerodhaTickerManager:
             parent.recompute_options_aggregate(spot_price=spot)
             self._last_aggregate_time[info.parent_symbol] = now
 
+            agg = parent.options_aggregate
+            logger.debug(
+                f"[ZerodhaWS] {info.parent_symbol} aggregate updated — "
+                f"strikes={len(parent.options_live)}, spot={spot}, "
+                f"pcr={agg.get('live_pcr', 0):.3f}, "
+                f"atm_strike={agg.get('atm_strike')}, "
+                f"straddle={agg.get('atm_straddle_premium', 0):.1f}"
+            )
+
             # Real-time options analysis (only when engine is enabled)
             if self.live_options_engine and spot:
                 self.live_options_engine.on_aggregate_updated(parent, spot)
@@ -333,6 +342,81 @@ class ZerodhaTickerManager:
                 logger.info(f"Subscribed {len(subscribe_tokens)} option tokens for {parent_symbol}")
             except Exception as e:
                 logger.error(f"Error subscribing options for {parent_symbol}: {e}")
+
+    # ─── Live Options Subscription ────────────────────────────────────
+
+    def subscribe_live_options(self, wait_for_ticks: bool = True) -> None:
+        """Subscribe Zerodha option tokens for all LIVE_OPTIONS_INDICES.
+
+        Replaces the old ``_subscribe_registered_options`` helper in
+        ``notification/commands/account.py``.  Can be called from any context
+        — init auto-connect, Telegram bot, or live_options_analysis — without
+        importing from the notification module.
+
+        Args:
+            wait_for_ticks: When True (default) sleeps 2 s so that the first
+                            index tick with spot price has time to arrive.
+                            Pass False when spot prices are already available.
+        """
+        from common.token_registry import TokenType, OptionZone
+        from common.constants import LIVE_OPTIONS_INDICES
+        from common.logging_util import logger
+        from notification.Notification import TELEGRAM_NOTIFICATIONS
+
+        registry = shared.app_ctx.token_registry
+        if registry is None:
+            logger.warning("[subscribe_live_options] token_registry not initialised, skip")
+            return
+
+        if wait_for_ticks:
+            import time as _time
+            _time.sleep(2)  # wait for first index tick with spot price
+
+        total_option_tokens = 0
+        option_lines = []
+
+        for token, index_obj in shared.app_ctx.index_token_obj_dict.items():
+            symbol = index_obj.stock_symbol
+
+            if symbol not in LIVE_OPTIONS_INDICES:
+                continue
+
+            option_tokens = registry.get_tokens_by_type(symbol, TokenType.OPTION)
+            if not option_tokens:
+                logger.warning(f"[subscribe_live_options] no option tokens registered for {symbol}")
+                continue
+
+            spot = index_obj.zerodha_data.get("last_price") or index_obj.ltp
+            if not spot or spot <= 0:
+                logger.warning(f"[subscribe_live_options] no spot price for {symbol}, skipping")
+                continue
+
+            self.subscribe_options_for_symbol(symbol, spot)
+            logger.info(f"[subscribe_live_options] option subscription initiated for {symbol} at spot {spot:.0f}")
+
+            subscribed_count = sum(
+                len(registry.get_option_tokens_by_zone(symbol, zone))
+                for zone in OptionZone
+            )
+            total_option_tokens += subscribed_count
+            option_lines.append(f"  {symbol}: {subscribed_count} tokens (spot {spot:.0f})")
+
+        index_count  = len(shared.app_ctx.index_token_obj_dict)
+        equity_count = len(shared.app_ctx.stock_token_obj_dict)
+        base_count   = index_count + (0 if self.index_only_mode else equity_count)
+        total        = base_count + total_option_tokens
+
+        mode_note = "index-only" if self.index_only_mode else f"{equity_count} equity + {index_count} index"
+        summary_lines = [
+            "WebSocket connected",
+            f"Base: {base_count} ({mode_note})",
+            f"Options: {total_option_tokens}",
+        ]
+        summary_lines.extend(option_lines)
+        summary_lines.append(f"Total: {total} / 500")
+
+        TELEGRAM_NOTIFICATIONS.send_notification("\n".join(summary_lines))
+        logger.info(f"[subscribe_live_options] subscription complete — total {total} tokens")
 
     # ─── Notification ──────────────────────────────────────────────────
 


### PR DESCRIPTION
Summary
Adds a full GEXAnalyser for NIFTY, BANKNIFTY, and SENSEX that models market-maker delta-hedging flows from gamma exposure. The analyser fires 5 signals, integrates into OptionSellerCompositeAnalyser (RANGE_BOUND and GAMMA_TRAP), and is backed by a 430-test suite. Includes a threading model hardening pass and several auxiliary improvements.

What is GEX?
GEX
strike
=
(
γ
CE
×
OI
CE
−
γ
PE
×
OI
PE
)
×
lot_size
×
spot
2
/
10
7
[
₹ crores
]
GEX 
strike
​
 =(γ 
CE
​
 ×OI 
CE
​
 −γ 
PE
​
 ×OI 
PE
​
 )×lot_size×spot 
2
 /10 
7
 [₹ crores]

Positive net GEX → dealers are long gamma → they sell rallies / buy dips → market pins / mean-reverts
Negative net GEX → dealers are short gamma → they amplify moves → market trends
GEX flip level = the strike where cumulative GEX (scanning outward from ATM) crosses zero
Requires gamma from Sensibull (OPTIONS_SOURCE=sensibull or OPTIONS_SOURCE=both). In Zerodha-only mode all gamma values are zero — all methods return False silently.

New Signals (GEXAnalyser.py)
Signal	Mode	Weight	Description
GEX_REGIME	both	0 (excluded from score)	Positive/negative gamma regime card. Detects cross-cycle regime flips. Persists to options_aggregate for downstream consumers.
GEX_FLIP_PROXIMITY	both	16	Spot within FLIP_PROXIMITY_THRESHOLD_PCT (0.4% intraday / 0.6% positional) of the zero-crossing strike. Skipped when `
GEX_WALL	both	15	Detects gamma concentration walls using a WALL_SIGMA (1.5σ intraday / 1.8σ positional) filter above WALL_MIN_GEX_CR minimum.
GEX_WALL_BREACH	intraday only	18	Fires when spot moves beyond a wall and dealer GEX at that strike drops ≥30% cycle-over-cycle (confirmed unwind, not just spot drift).
GEX_IMBALANCE	both	13	CE/PE gamma dominance > 2.5× ratio with both sides above minimum noise floor.
Thresholds are calibrated per mode via reset_constants(): intraday = more sensitive (narrower proximity, looser wall filter); positional = wider (accounts for gap risk).

Composite Analyser Integration (OptionSellerCompositeAnalyser.py)
RANGE_BOUND_SETUP — new R6 condition: GEX_POSITIVE_REGIME (MODERATE/STRONG) contributes as the 6th confirmatory leg, reinforcing mean-reversion bias when dealers are structurally long gamma.
GAMMA_TRAP — G1 Wall Breach expansion: GEX_WALL_BREACH is now an alternative trigger for the G1 (wall breach) gate alongside OI_CAPITULATION/OI_WALL_MIGRATION. Direction is inferred from breach_side (CALL breach → bullish, PUT breach → bearish).
Both existing signals get richer triggers dicts in Telegram messages (e.g. "G1 Wall Breach": "GEX CALL wall 24500 broken, dealer GEX dropped 42%").
Constants (constants.py)
INDEX_LOT_SIZES — lot sizes for NIFTY (75), BANKNIFTY (15), SENSEX (10), FINNIFTY (40) used for absolute GEX computation in ₹ crores.
GEX signal weights added to ANALYSIS_WEIGHTS.
GEX signals added to OPTIONS_ANALYSES set.
GEX_REGIME added to NEUTRAL_EXCLUDE_FROM_SCORE.
ENV_THREAD_POOL_WORKERS / THREAD_POOL_WORKERS — tunable thread pool size (default 20).
Threading Hardening (intraday_monitor.py)
ThreadPoolExecutor is now module-level — initialised once in init(), reused every 310s cycle. Eliminates 20× thread-creation/teardown overhead per cycle.
Pool workers default to THREAD_POOL_WORKERS (env-tunable); graceful shutdown(wait=False, cancel_futures=True) on exit.
_stale_alerts_sent set is now protected by _stale_alerts_lock (threading.Lock()); lock released before I/O (no lock-held-over-network).
_live_options_subscribed guard prevents double-subscription on reconnect.
TickStore (tick_store.py)
Six new fields initialised in options_aggregate default: gex_total, gex_ce, gex_pe, gex_regime, gex_flip_level, gex_by_strike. gex_by_strike persists cross-cycle for the GEX_WALL_BREACH delta comparison.
Zerodha Analysis (zerodha_analysis.py)
Extracted subscribe_live_options() method out of account.py into ZerodhaAnalysis — callable from init, bot commands, or live_options_analysis without importing the notification module.
Richer on_aggregate_updated debug log (strikes, spot, PCR, ATM strike, straddle premium).
Message Formatters (MessageFormatter.py)
_fmt_gex_regime — informational regime card (not a trade signal card).
_fmt_gex_wall_breach — shows dealer GEX before/after at breached strike with drop %.
_fmt_gex_imbalance — shows CE/PE GEX ratio with magnitude label.
RANGE_BOUND and GAMMA_TRAP formatters updated to consume the new triggers dict keys (G1 Wall Breach, R6 GEX).
HTTP Timeout Fix (sensibull_fetcher.py)
All requests calls changed from single-value timeout=N to split connect/read timeouts timeout=(5, N) per project convention.

Tests (test_gex_analyser.py)
430 lines across 7 test classes:

Class	Coverage
TestGates	No gamma data → skip; non-index → skip; zero spot → skip
TestGexRegime	Positive / negative regime; flip detection across cycles
TestGexFlipProximity	Within threshold fires; outside does not; noise floor gate
TestGexWall	Wall detected above σ threshold; below threshold no signal
TestGexWallBreach	Spot beyond wall + GEX drop ≥ 30% fires; partial conditions don't
TestGexImbalance	CE/PE dominance ratio; noise floor; both directions
TestResetConstants	Intraday vs positional threshold calibration
Files Changed
File	Change
GEXAnalyser.py	New — 719 lines
test_gex_analyser.py	New — 430 lines
constants.py	GEX weights, lot sizes, thread pool constant
OptionSellerCompositeAnalyser.py	R6 GEX condition, GEX_WALL_BREACH G1 gate
MessageFormatter.py	3 new formatters, updated RANGE_BOUND/GAMMA_TRAP
intraday_monitor.py	Module-level thread pool, stale-alert lock, GEXAnalyser registration
tick_store.py	GEX fields in options_aggregate default
zerodha_analysis.py	subscribe_live_options() extracted, richer debug log
sensibull_fetcher.py	Split HTTP timeouts
account.py	Delegate to zerodha_analysis.subscribe_live_options()
CLAUDE.md	Updated architecture notes (GEXAnalyser registration, threading model)