### PR TITLE
Discord Notification Channel + Zerodha WS Hardening

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,7 @@
+########NOTIFICATION CHANNEL
+# Controls where alerts are sent: "telegram" | "discord" | "both" (default: telegram)
+NOTIFICATION_CHANNEL=telegram
+
 ########TELEGRAM BOTs
 
 TELEGRAM_INTRADAY_TOKEN=<your_intraday_bot_token>
@@ -10,6 +14,13 @@ TELEGRAM_POSITIONAL_CHAT_ID=<your_positional_chat_id>
 # Create a new bot via @BotFather and a new group/channel, then fill these in.
 TELEGRAM_LIVE_OPTIONS_TOKEN=<your_live_options_bot_token>
 TELEGRAM_LIVE_OPTIONS_CHAT_ID=<your_live_options_chat_id>
+
+########DISCORD WEBHOOKS
+# Create webhooks in Discord: Channel Settings → Integrations → Webhooks → New Webhook
+# Only needed when NOTIFICATION_CHANNEL=discord or NOTIFICATION_CHANNEL=both
+DISCORD_INTRADAY_WEBHOOK_URL=https://discord.com/api/webhooks/1516879754018557965/YR97KJS4Dp9PwU-yD-UnTC92YooSByHsXpGfElIsaZGGJJnRhbqRXikFOEa_Y--bZ10c
+DISCORD_POSITIONAL_WEBHOOK_URL=https://discord.com/api/webhooks/1517041786747621417/y0vTg-moTv7Ak6wwpMBRMoAOrTPQ21zkbya4Jr7HSxq_2RvMWpL_k_nswON786-2iIqK
+DISCORD_LIVE_OPTIONS_WEBHOOK_URL=https://discord.com/api/webhooks/1517041868993593425/uHwPY3GBDP8cxLuhJPJaFnec0rnyEHCXEr_S5mFIwfp-eLM6qLMqRYwkH5gT11bdJdH7
 
 ########PRODUCTION ENVs
 
@@ -65,7 +76,7 @@ AWS_SECRET_ACCESS_KEY=<your_aws_secret_access_key>
 
 DEV_INTRADAY=0
 DEV_POSITIONAL=0
-DEV_NOTIFY=0          # Set to 1 to send Telegram alerts while in dev mode
+DEV_NOTIFY=0          # Set to 1 to send alerts in dev mode (via NOTIFICATION_CHANNEL)
 
 # Max number of intraday analysis cycles in dev mode before stopping.
 # 0 = run indefinitely (original behaviour). e.g. DEV_MAX_CYCLES=3 runs 3 cycles then stops.

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ data/stocks/
 *.pkl
 *.joblib
 *.parquet
+# CocoIndex Code (ccc)
+/.cocoindex_code/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,162 +1,40 @@
-# StockAnalysis — Claude Context
+# 🚨 CRITICAL: BEHAVIOR & TOKEN EFFICIENCY
+- **ABSOLUTE NO YAPPING:** You are interacting with an automated pipeline. Do not explain the code you write. Do not summarize changes. Do not output pleasantries, introductory, or concluding phrases. 
+- **ALLOWED OUTPUT:** Output ONLY raw code, terminal commands, or necessary file patch modifications. Any conversational text is a strict violation of system constraints.
+- **NO FULL-FILE REWRITES:** Use your edit/patch tools to modify specific functions. NEVER output an entire file into the chat.
+- **TESTING AUTONOMY:** Run tests (e.g., `make test-fast`) to verify work. If a test fails, fix it autonomously. Do not ask for permission.
 
-Indian NSE/BSE equity & derivatives intraday/positional analysis system.
-Zerodha KiteConnect WebSocket + Sensibull REST/WS + yfinance + Telegram alerts.
+# Semantic Search (CRITICAL)
+- You are connected to the `cocoindex-code` MCP server.
+- **DO NOT** use `grep`, `find`, or read entire directories. 
+- Use the semantic search tool to locate classes/functions first, then read specific files.
 
-## Commands
 
-```bash
-make venv && make install-dev   # first-time setup
-make run-dev                    # dev intraday loop (PRODUCTION=0 DEV_INTRADAY=1)
-make run-dev-positional         # dev EOD run
-make run-dev-stock-intraday STOCK=RELIANCE   # single stock
-make run-dev-index-intraday INDEX=NIFTY      # single index
-make test                       # full pytest suite
-make test-fast                  # stop on first failure
-make lint                       # ruff check
-make format                     # ruff format
-make typecheck                  # pyright
-make deploy                     # rsync + SSH to production server
-make server-ssh                 # open SSH session to production
-make server-logs-500            # last 500 lines of stock_monitor.log on server
-```
+# Architecture & Constraints
+- Indian NSE/BSE equity & derivatives analysis.
+- Zerodha KiteConnect WebSocket + Sensibull REST/WS + yfinance + Telegram.
+- **Entry point:** `intraday/intraday_monitor.py`
+- **Signal Correlation:** `SignalBus` → `SignalCorrelator` → `MarketNarrator` (Gemini Flash LLM).
+- **Registration Order:** `OptionSellerCompositeAnalyser` MUST be registered last.
+- **Options Source:** When `OPTIONS_SOURCE=both`, Zerodha is authoritative. Sensibull enriches ONLY `{delta, gamma, theta, vega, iv, iv_change}` via `TickStore.update_option_tick(merge=True)`.
 
-Entry point: `intraday/intraday_monitor.py`
 
-## Architecture
+# Communication & Token Efficiency
+- **No Yapping:** Do not explain the code you write unless I explicitly ask "why?". Output only the code, terminal commands, or necessary file modifications. Skip all pleasantries and introductory phrases.
+- **No Full-File Rewrites:** Use your edit/patch tools to modify specific functions or lines. **NEVER** output or rewrite an entire file into the chat.
+- **Testing Autonomy:** When writing or modifying features, run the relevant tests (e.g., `make test-fast`) to verify your work. If a test fails, read the error and iterate autonomously until it passes. Do not stop to ask me for permission to fix your own errors.
 
-### Analyser Framework
-- `BaseAnalyzer` (decorator pattern): `@BaseAnalyzer.intraday`, `@BaseAnalyzer.positional`, `@BaseAnalyzer.index_intraday`, `@BaseAnalyzer.index_positional`
-- `AnalyserOrchestrator`: collects all registered analysers, calls them in order
-- **Registration order matters** — `OptionSellerCompositeAnalyser` MUST be registered last (reads signals from all other analysers including `PANIC_EXHAUSTION`)
-- Current registration order (10 analysers): VolumeAnalyser → TechnicalAnalyser → CandleStickAnalyser → IVAnalyser → FuturesAnalyser → PCRAnalyser → MaxPainAnalyser → OIChainAnalyser → GEXAnalyser → PanicModeAnalyser → **OptionSellerCompositeAnalyser**
+# Coding Conventions
+- **No `print()`:** Always use `logger.info/debug/warning/error` from `common/logging_util.py`.
+- **HTTP Timeouts:** Always split connect/read (e.g., `timeout=(5, 10)`).
+- **Environment Variables:** Read via `os.getenv()` using constants in `common/constants.py`.
+- **Logging Format:** Must use exactly: `[SIGNAL_KEY] <symbol> | SOURCE <raw_field>=<value>`.
+- **Log Levels:** `DEBUG` for gates/conditions. `INFO` strictly for `EMITTED` events. `ERROR` with `traceback.format_exc()` for exceptions.
 
-### Scoring & Notifications
-- `ANALYSIS_WEIGHTS` in `common/constants.py` — each signal key has a weight
-- `MIN_NOTIFICATION_SCORE = 110` (intraday), `MIN_NOTIFICATION_SCORE_POSITIONAL = 150` (EOD)
-- `PRIORITY_OVERRIDE` flag bypasses score gate entirely (used by composite setups)
-- `OptionSellerCompositeAnalyser` has weight=0 — never inflates batch scores; bypasses via `PRIORITY_OVERRIDE` only
-- `NEUTRAL_EXCLUDE_FROM_SCORE` — signals excluded from score aggregation (composite keys)
-
-### OPTIONS_SOURCE Modes
-Three modes controlled by `OPTIONS_SOURCE` env var:
-- `zerodha` (default): tick-accurate OI/ltp/depth, no Greeks
-- `sensibull`: Greeks/IV/max pain, ~10-30s snapshots, no auth required
-- `both`: Zerodha is **authoritative** (ltp, OI, engine trigger); Sensibull **enriches only** existing strikes with Greeks/IV
-
-**Critical invariant for `OPTIONS_SOURCE=both`:**
-- `SensibullAdapter.apply(enrichment_only=True)` writes ONLY `{delta, gamma, theta, vega, iv, iv_change}` via `TickStore.update_option_tick(merge=True)`
-- Sensibull NEVER calls `recompute_options_aggregate()` or `on_aggregate_updated()` in this mode — Zerodha owns those
-- `TickStore.update_option_tick(merge=True)` silently skips strikes not yet created by Zerodha (Zerodha is authoritative creator)
-
-### Threading Model
-- `ThreadPoolExecutor` is **module-level** (initialised once in `init()`, not inside `with` block per cycle)
-- `max_workers` defaults to 20 (i5-6200U, I/O-bound); tunable via `THREAD_POOL_WORKERS` env var
-- `price_future.result(timeout=60)` — yfinance bulk download has hard 60s timeout
-- `as_completed(..., timeout=90)` — per-stock analysis batch has hard 90s timeout with future cancellation
-- `_stale_alerts_sent` set is protected by `_stale_alerts_lock` (threading.Lock)
-- `AppContext` singleton (`common/shared.py`) is read-only in worker threads — safe
-
-### Intelligence Layer
-- `SignalBus` (pub/sub) → `SignalCorrelator` (cross-layer confluence detection) → `MarketNarrator` (Gemini Flash LLM)
-- Morning bias: runs positional analysers on 1y daily data before market open, emits signals to `SignalBus`
-- Requires `ENABLE_INTELLIGENCE=1`; LLM requires `ENABLE_NARRATOR=1` + `GEMINI_API_KEY`
-
-## Coding Conventions
-
-- **Never use `print()`** — always `logger.info/debug/warning/error` from `common/logging_util.py`
-- **HTTP timeouts**: always split connect/read — `requests.get(url, timeout=(5, 10))` not `timeout=10`
-- **Env vars**: all defined as constants in `common/constants.py` (e.g. `ENV_PRODUCTION = "PRODUCTION"`); read via `os.getenv(constant.ENV_PRODUCTION)`
-- **`load_dotenv(override=True)`** is called in `init()` — never call it again elsewhere
-- Do not add `@BaseAnalyzer.intraday` / `@BaseAnalyzer.positional` decorators to `OptionSellerCompositeAnalyser` methods — it overrides `run_all_intraday_analyses()` and `run_all_positional_analyses()` directly
-- Python version: **3.12.3** on production server, **3.13.3** on local dev machine
-
-### Analyser Logging Pattern
-
-Every analyser method **must** follow this exact logging structure (see `IVAnalyser.py` and `GEXAnalyser.py` as canonical examples):
-
-```python
-def analyse_signal_name(self, stock: Stock) -> bool:
-    try:
-        logger.debug(f"[SIGNAL_KEY] {stock.stock_symbol} — start")
-
-        # Gate checks (skip silently at DEBUG)
-        if <no data>:
-            logger.debug(f"[SIGNAL_KEY] {stock.stock_symbol} — <reason>, skip")
-            return False
-
-        # Source data log (what raw data was fetched)
-        logger.debug(
-            f"[SIGNAL_KEY] {stock.stock_symbol} | "
-            f"SOURCE <raw_field>=<value> ..."
-        )
-
-        # Condition evaluation log (computed values vs thresholds)
-        logger.debug(
-            f"[SIGNAL_KEY] {stock.stock_symbol} | "
-            f"INPUT <processed>=<value> | "
-            f"CONDITION <value> <op> <threshold>"
-        )
-
-        if <condition met>:
-            stock.set_analysis(...)
-            logger.info(
-                f"[SIGNAL_KEY] {stock.stock_symbol} — EMITTED | "
-                f"<key>=<value> ..."
-            )
-            return True
-
-        logger.debug(
-            f"[SIGNAL_KEY] {stock.stock_symbol} — no signal | "
-            f"<reason why condition failed>"
-        )
-        return False
-
-    except Exception as e:
-        logger.error(f"[SIGNAL_KEY] {stock.stock_symbol} — exception: {e}")
-        logger.error(traceback.format_exc())
-        return False
-```
-
-**Rules:**
-- `[SIGNAL_KEY]` prefix must match the key used in `stock.set_analysis()` and `ANALYSIS_WEIGHTS`
-- `start` log always first line in try block
-- `SOURCE` line: raw input values before any processing
-- `INPUT ... | CONDITION ...` line: computed values and the threshold being tested
-- Signal emitted → `logger.info` with `EMITTED` keyword and key metrics
-- Signal not emitted → `logger.debug` with `no signal | <reason>`
-- All exceptions → `logger.error` + `traceback.format_exc()`
-- Never `logger.info` for skipped/no-signal paths — keep INFO clean for actionable events only
-
-## Environment & Deployment
-
-- **Production server**: `hacker@100.92.21.31` (Tailscale VPN — NOT an EC2 instance, physical machine)
-- **OS**: Ubuntu 24.04.4 LTS, hostname `Hacker-computer`
-- **App dir on server**: `/home/hacker/StockAnalysis`
-- **Log file**: `logs/stock_monitor.log` (local and server)
-- **Systemd timers**: `stockanalysis.timer` (9:00 AM IST) + `stockanalysis-positional.timer` (8:00 PM IST)
-- **Auth service**: `stockanalysis-auth.service` runs `auth/auth_login.py` (TOTP via `pyotp`) before each analysis run, writes fresh `ZERODHA_ENC_TOKEN` to `.env`
-- `.env` is git-ignored; copy `.env.template` and fill in values
-- Do not suggest AWS EC2 CLI commands — deployment uses direct SSH + rsync
-
-## Testing
-
-- Tests in `tests/`, mirrors package structure (e.g. `tests/analyser/`, `tests/common/`)
-- `pytest` with `asyncio_mode = auto` — no `@pytest.mark.asyncio` needed
-- `DeprecationWarning` treated as error except for `telegram`, `anyio`, `pytest_asyncio`
-- Run a single module: `make test-module MODULE=analyser`
-
-## Key Files
-
-| File | Purpose |
-|---|---|
-| `intraday/intraday_monitor.py` | Main entry point, loop orchestration, `init()`, `fetch_and_analyze_stocks()` |
-| `common/constants.py` | All env var names, scoring weights, thresholds |
-| `common/shared.py` | `AppContext` singleton (`app_ctx`) |
-| `common/Stock.py` | Stock data model (`priceData`, `options_live`, `options_aggregate`, `analysis`) |
-| `analyser/Analyser.py` | `BaseAnalyzer` + `AnalyserOrchestrator` |
-| `analyser/OptionSellerCompositeAnalyser.py` | Cross-analyser composite (GAMMA_TRAP, RANGE_BOUND_SETUP, SKEW_FADE_SETUP) |
-| `fno/sensibull_adapter.py` | Translates Sensibull snapshots → Stock fields (enrichment_only mode) |
-| `zerodha/tick_store.py` | Thread-safe live tick container (`merge=True` for enrichment) |
-| `auth/auth_login.py` | TOTP-based automated Zerodha login |
-| `common/scoring.py` | `calculate_score`, `should_notify`, `NotificationPriority`, `ScoreResult` |
+# Commands
+- `make run-dev` : Dev intraday loop
+- `make run-dev-positional` : Dev EOD run
+- `make test-fast` : Pytest suite (stop on first fail)
+- `make lint` / `make format` / `make typecheck` : Ruff / Pyright
+- `make deploy` : rsync + SSH to production
+- `make server-logs-500` : Check production `stock_monitor.log`

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ help:
 	@echo "    update-derivatives  Refresh final_derivatives_list.json from Zerodha + NSE"
 	@echo "    logs          Tail stock_monitor.log (last 50 lines)"
 	@echo "    logs-500      Tail stock_monitor.log (last 500 lines)"
+	@echo "    logs-1000     Tail stock_monitor.log (last 1000 lines)"
 	@echo "    logs-follow   Follow stock_monitor.log live"
 	@echo "    logs-grep     Grep stock_monitor.log: make logs-grep Q=RELIANCE"
 	@echo "    clean         Remove __pycache__, .pyc, pytest cache"
@@ -61,8 +62,10 @@ help:
 	@echo "    server-ssh          Open interactive SSH session"
 	@echo "    server-logs         Tail last 50 lines of stock_monitor.log on server"
 	@echo "    server-logs-500     Tail last 500 lines of stock_monitor.log on server"
+	@echo "    server-logs-1000    Tail last 1000 lines of stock_monitor.log on server"
 	@echo "    server-logs-follow  Live-follow stock_monitor.log on server"
 	@echo "    server-status       Show stock_analysis.service status"
+	@echo "    server-start        Start stock_analysis.service"
 	@echo "    server-restart      Restart stock_analysis.service"
 	@echo "    server-stop         Stop stock_analysis.service"
 	@echo "    server-pull         git pull on server repo"
@@ -230,6 +233,10 @@ logs:
 logs-500:
 	@tail -500 $(LOG_FILE) 2>/dev/null || echo "No $(LOG_FILE) found."
 
+.PHONY: logs-1000
+logs-1000:
+	@tail -1000 $(LOG_FILE) 2>/dev/null || echo "No $(LOG_FILE) found."
+
 .PHONY: logs-follow
 logs-follow:
 	@tail -f $(LOG_FILE) 2>/dev/null || echo "No $(LOG_FILE) found."
@@ -271,6 +278,10 @@ server-logs:
 server-logs-500:
 	ssh $(SERVER) "tail -500 $(SERVER_LOG)"
 
+.PHONY: server-logs-1000
+server-logs-1000:
+	ssh $(SERVER) "tail -1000 $(SERVER_LOG)"
+
 .PHONY: server-logs-follow
 server-logs-follow:
 	ssh $(SERVER) "tail -f $(SERVER_LOG)"
@@ -278,6 +289,10 @@ server-logs-follow:
 .PHONY: server-status
 server-status:
 	ssh $(SERVER) "systemctl status stockanalysis.service"
+
+.PHONY: server-start
+server-start:
+	ssh $(SERVER) "sudo systemctl start stockanalysis.service"
 
 .PHONY: server-restart
 server-restart:

--- a/common/constants.py
+++ b/common/constants.py
@@ -75,6 +75,13 @@ TELEGRAM_LIVE_OPTIONS_CHAT_ID  = os.environ.get("TELEGRAM_LIVE_OPTIONS_CHAT_ID",
 
 TELEGRAM_URL = 'https://api.telegram.org/bot'
 
+# Discord webhook URLs (alternative notification channel)
+# NOTIFICATION_CHANNEL: "telegram" | "discord" | "both" (default: telegram)
+NOTIFICATION_CHANNEL             = os.environ.get("NOTIFICATION_CHANNEL", "telegram")
+DISCORD_INTRADAY_WEBHOOK_URL     = os.environ.get("DISCORD_INTRADAY_WEBHOOK_URL", "")
+DISCORD_POSITIONAL_WEBHOOK_URL   = os.environ.get("DISCORD_POSITIONAL_WEBHOOK_URL", "")
+DISCORD_LIVE_OPTIONS_WEBHOOK_URL = os.environ.get("DISCORD_LIVE_OPTIONS_WEBHOOK_URL", "")
+
 #FILE NAMES
 DERIVATIVE_LIST_FILENAME = "final_derivatives_list.json"
 STOCK_DATA_FILENAME = "stock_data.json"

--- a/notification/Notification.py
+++ b/notification/Notification.py
@@ -1,5 +1,6 @@
 
 # Import the following modules
+import re
 import requests
 import json
 import os
@@ -12,8 +13,45 @@ from common.constants import (
     TELEGRAM_LIVE_OPTIONS_CHAT_ID,
     TELEGRAM_URL,
     ENV_PRODUCTION,
+    NOTIFICATION_CHANNEL,
+    DISCORD_INTRADAY_WEBHOOK_URL,
+    DISCORD_POSITIONAL_WEBHOOK_URL,
+    DISCORD_LIVE_OPTIONS_WEBHOOK_URL,
 )
 from common.logging_util import logger
+
+
+def _html_to_discord(text: str) -> str:
+    """Convert Telegram HTML tags to Discord markdown."""
+    text = re.sub(r"<b>(.*?)</b>", r"**\1**", text, flags=re.DOTALL)
+    text = re.sub(r"<i>(.*?)</i>", r"*\1*", text, flags=re.DOTALL)
+    text = re.sub(r"<code>(.*?)</code>", r"`\1`", text, flags=re.DOTALL)
+    text = re.sub(r"<pre>(.*?)</pre>", r"```\1```", text, flags=re.DOTALL)
+    text = re.sub(r"<[^>]+>", "", text)  # strip remaining tags
+    return text
+
+
+def _send_discord(webhook_url: str, message: str, parse_mode: str | None = None) -> bool:
+    """POST a message to a Discord webhook. Returns True on success."""
+    if not webhook_url:
+        return False
+    content = _html_to_discord(message) if parse_mode and parse_mode.upper() == "HTML" else message
+    # Discord message limit is 2000 chars
+    if len(content) > 2000:
+        content = content[:1997] + "..."
+    try:
+        resp = requests.post(
+            webhook_url,
+            json={"content": content},
+            timeout=(5, 10),
+        )
+        if resp.status_code not in (200, 204):
+            logger.error(f"Discord webhook failed: {resp.status_code}: {resp.text}")
+            return False
+        return True
+    except Exception as e:
+        logger.error(f"Discord webhook error: {e}")
+        return False
  
 # Function to send Push Notification
  
@@ -38,84 +76,92 @@ class TELEGRAM_NOTIFICATIONS:
             print('Message sent')
     @classmethod
     def send_notification(cls, message, parse_mode=None):
-        """Send a Telegram message.
-
-        Args:
-            message: The text to send.
-            parse_mode: Optional. 'HTML' or 'Markdown' for rich formatting.
-                        None sends as plain text (backward-compatible default).
-        """
+        """Send a notification via Telegram, Discord, or both (controlled by NOTIFICATION_CHANNEL)."""
         if not cls.is_production and not cls.dev_notify:
             return
-        TELEGRAM_CHAT_ID = ""
-        TELEGRAM_TOKEN = ""
-        if TELEGRAM_NOTIFICATIONS.is_intraday:
-            TELEGRAM_CHAT_ID = TELEGRAM_INTRADAY_CHAT_ID
-            TELEGRAM_TOKEN = TELEGRAM_INTRADAY_TOKEN
-        else:
-            TELEGRAM_CHAT_ID = TELEGRAM_POSITIONAL_CHAT_ID
-            TELEGRAM_TOKEN = TELEGRAM_POSITIONAL_TOKEN
-            
-        msg = {"chat_id": TELEGRAM_CHAT_ID, "text": message}
-        if parse_mode:
-            msg["parse_mode"] = parse_mode
-        resp = None
-        for attempt in range(1, 4):  # up to 3 attempts
-            try:
-                resp = requests.post(
-                    TELEGRAM_URL + TELEGRAM_TOKEN + "/sendMessage",
-                    json=msg,
-                    timeout=15,
-                )
-                
-                if resp.status_code != 200:
-                    logger.error(f"Telegram send failed (attempt {attempt}) with status {resp.status_code}: {resp.text}")
+
+        channel = NOTIFICATION_CHANNEL.lower()
+
+        if channel in ("discord", "both"):
+            webhook = (
+                DISCORD_INTRADAY_WEBHOOK_URL
+                if TELEGRAM_NOTIFICATIONS.is_intraday
+                else DISCORD_POSITIONAL_WEBHOOK_URL
+            )
+            _send_discord(webhook, message, parse_mode)
+
+        if channel in ("telegram", "both"):
+            TELEGRAM_CHAT_ID = ""
+            TELEGRAM_TOKEN = ""
+            if TELEGRAM_NOTIFICATIONS.is_intraday:
+                TELEGRAM_CHAT_ID = TELEGRAM_INTRADAY_CHAT_ID
+                TELEGRAM_TOKEN = TELEGRAM_INTRADAY_TOKEN
+            else:
+                TELEGRAM_CHAT_ID = TELEGRAM_POSITIONAL_CHAT_ID
+                TELEGRAM_TOKEN = TELEGRAM_POSITIONAL_TOKEN
+
+            msg = {"chat_id": TELEGRAM_CHAT_ID, "text": message}
+            if parse_mode:
+                msg["parse_mode"] = parse_mode
+            for attempt in range(1, 4):
+                try:
+                    resp = requests.post(
+                        TELEGRAM_URL + TELEGRAM_TOKEN + "/sendMessage",
+                        json=msg,
+                        timeout=15,
+                    )
+                    if resp.status_code != 200:
+                        logger.error(f"Telegram send failed (attempt {attempt}) with status {resp.status_code}: {resp.text}")
+                        if attempt < 3:
+                            from time import sleep as _sleep
+                            _sleep(2 ** attempt)
+                        continue
+                    logger.info("Message sent successfully")
+                    logger.debug(f"Message: {message}")
+                    return True
+                except requests.Timeout:
+                    logger.error(f"Telegram send timeout (attempt {attempt})")
                     if attempt < 3:
                         from time import sleep as _sleep
-                        _sleep(2 ** attempt)  # 2s, 4s back-off
-                    continue
-                
-                logger.info("Message sent successfully")
-                logger.debug(f"Message: {message}")
-                return True
-                
-            except requests.Timeout:
-                logger.error(f"Telegram send timeout (attempt {attempt})")
-                if attempt < 3:
-                    from time import sleep as _sleep
-                    _sleep(2 ** attempt)
-            except requests.ConnectionError:
-                logger.error(f"Telegram connection error (attempt {attempt})")
-                if attempt < 3:
-                    from time import sleep as _sleep
-                    _sleep(2 ** attempt)
-            except Exception as e:
-                logger.error(f"Telegram send failed: {e}")
-                return False
+                        _sleep(2 ** attempt)
+                except requests.ConnectionError:
+                    logger.error(f"Telegram connection error (attempt {attempt})")
+                    if attempt < 3:
+                        from time import sleep as _sleep
+                        _sleep(2 ** attempt)
+                except Exception as e:
+                    logger.error(f"Telegram send failed: {e}")
+                    return False
 
-        return False
+        return True
 
     @classmethod
     def send_live_options_notification(cls, message, parse_mode="HTML"):
-        """Send a real-time options alert to the dedicated live options Telegram channel."""
+        """Send a real-time options alert to the dedicated live options channel."""
         if not cls.is_production and not cls.dev_notify:
             return
-        if not TELEGRAM_LIVE_OPTIONS_TOKEN or not TELEGRAM_LIVE_OPTIONS_CHAT_ID:
-            logger.debug("TELEGRAM_LIVE_OPTIONS_TOKEN/CHAT_ID not configured — skipping live options alert")
-            return False
-        msg = {"chat_id": TELEGRAM_LIVE_OPTIONS_CHAT_ID, "text": message}
-        if parse_mode:
-            msg["parse_mode"] = parse_mode
-        try:
-            resp = requests.post(
-                TELEGRAM_URL + TELEGRAM_LIVE_OPTIONS_TOKEN + "/sendMessage",
-                json=msg,
-                timeout=10
-            )
-            if resp.status_code != 200:
-                logger.error(f"Live options Telegram send failed: {resp.status_code}: {resp.text}")
-                return False
-            return True
-        except Exception as e:
-            logger.error(f"Live options Telegram send failed: {e}")
-            return False
+
+        channel = NOTIFICATION_CHANNEL.lower()
+
+        if channel in ("discord", "both"):
+            _send_discord(DISCORD_LIVE_OPTIONS_WEBHOOK_URL, message, parse_mode)
+
+        if channel in ("telegram", "both"):
+            if not TELEGRAM_LIVE_OPTIONS_TOKEN or not TELEGRAM_LIVE_OPTIONS_CHAT_ID:
+                logger.debug("TELEGRAM_LIVE_OPTIONS_TOKEN/CHAT_ID not configured — skipping live options Telegram alert")
+            else:
+                msg = {"chat_id": TELEGRAM_LIVE_OPTIONS_CHAT_ID, "text": message}
+                if parse_mode:
+                    msg["parse_mode"] = parse_mode
+                try:
+                    resp = requests.post(
+                        TELEGRAM_URL + TELEGRAM_LIVE_OPTIONS_TOKEN + "/sendMessage",
+                        json=msg,
+                        timeout=10,
+                    )
+                    if resp.status_code != 200:
+                        logger.error(f"Live options Telegram send failed: {resp.status_code}: {resp.text}")
+                except Exception as e:
+                    logger.error(f"Live options Telegram send failed: {e}")
+
+        return True

--- a/zerodha/zerodha_analysis.py
+++ b/zerodha/zerodha_analysis.py
@@ -84,7 +84,7 @@ class ZerodhaTickerManager:
             self.is_enctoken_updated = False
             return False
         finally:
-            if not self.connected:
+            if not (self._kt and self._kt.is_connected()):
                 logger.error("Failed to connect to Zerodha WebSocket after multiple attempts")
                 self.close_connection()
 
@@ -477,6 +477,47 @@ class ZerodhaTickerManager:
     def on_error(self, ws, code, reason):
         logger.error(f"Error in connection. Code: {code}, Reason: {reason}")
         self.stop_tick_processor()
+        # 403 = enctoken expired — alert and trigger a fresh login in a background thread.
+        # The auth script writes the new token to .env; the next reconnect attempt picks it up.
+        if "403" in str(reason):
+            logger.warning("[ZerodhaWS] 403 Forbidden — enctoken expired mid-session, re-authing")
+            from notification.Notification import TELEGRAM_NOTIFICATIONS
+            TELEGRAM_NOTIFICATIONS.send_notification(
+                "⚠️ <b>Zerodha WS 403 — enctoken expired</b>\n"
+                "Attempting automatic re-login via auth_login.py…",
+                parse_mode="HTML",
+            )
+            import threading
+            def _reauth():
+                try:
+                    import subprocess, sys, os
+                    script = os.path.join(os.path.dirname(os.path.dirname(__file__)), "auth", "auth_login.py")
+                    result = subprocess.run(
+                        [sys.executable, script, "--force"],
+                        capture_output=True, text=True, timeout=60,
+                    )
+                    if result.returncode == 0:
+                        logger.info("[ZerodhaWS] re-auth succeeded — new enctoken written to .env")
+                        # Reload the new token and reconnect
+                        from dotenv import load_dotenv
+                        load_dotenv(override=True)
+                        import common.constants as _c
+                        from urllib.parse import quote as _quote
+                        new_token = os.getenv(_c.ENV_ZERODHA_ENC_TOKEN, "")
+                        if new_token:
+                            self.update_enctoken(_quote(new_token, safe=""))
+                            if self.connect():
+                                logger.info("[ZerodhaWS] reconnected with fresh enctoken")
+                                self.subscribe_live_options(wait_for_ticks=True)
+                    else:
+                        logger.error(f"[ZerodhaWS] re-auth failed: {result.stderr[:200]}")
+                        TELEGRAM_NOTIFICATIONS.send_notification(
+                            "🚨 <b>Zerodha re-auth FAILED</b> — manual intervention required",
+                            parse_mode="HTML",
+                        )
+                except Exception as e:
+                    logger.error(f"[ZerodhaWS] re-auth exception: {e}")
+            threading.Thread(target=_reauth, name="ws-reauth", daemon=True).start()
 
     def on_ticks(self, ws, ticks):
         import time
@@ -489,9 +530,9 @@ class ZerodhaTickerManager:
     def on_reconnect(self, ws, attempts_count):
         self.reconnect_attempts = attempts_count
         logger.info(f"Reconnected to Zerodha WebSocket. Attempt: {self.reconnect_attempts}")
-        # Re-subscribe option tokens — on_connect only restores base (equity/index) tokens.
-        # Options subscriptions are lost on disconnect and must be re-established.
-        if self.live_options_engine is not None:
+        # Only re-subscribe options if this looks like a genuine reconnect (not a 403 loop).
+        # The 403 re-auth path in on_error handles subscription after token refresh.
+        if self.live_options_engine is not None and self._kt and self._kt.is_connected():
             import threading
             def _resubscribe():
                 self.subscribe_live_options(wait_for_ticks=True)


### PR DESCRIPTION
Summary
Introduces Discord as an alternative (or parallel) notification channel alongside Telegram, and hardens the Zerodha WebSocket connection against mid-session 403 / enctoken expiry.

Changes
[Notification.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Discord support
Added _html_to_discord() converter that maps Telegram HTML tags (<b>, <i>, <code>, <pre>) to Discord markdown, and strips any remaining HTML.
Added _send_discord(webhook_url, message, parse_mode) — posts to a Discord webhook with the 2000-char limit enforced and structured error logging.
Refactored send_notification() and send_live_options_notification() to route based on NOTIFICATION_CHANNEL env var (telegram | discord | both). Existing Telegram behaviour is fully preserved when NOTIFICATION_CHANNEL=telegram (default).
[constants.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — new env constants
NOTIFICATION_CHANNEL (default: "telegram")
DISCORD_INTRADAY_WEBHOOK_URL
DISCORD_POSITIONAL_WEBHOOK_URL
DISCORD_LIVE_OPTIONS_WEBHOOK_URL
[.env.template](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — documented new variables
Added NOTIFICATION_CHANNEL with inline comment explaining valid values.
Added DISCORD_* webhook placeholders with setup instructions.
Updated DEV_NOTIFY comment to be channel-agnostic.
[zerodha_analysis.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — 403 / enctoken auto-recovery
on_error: detects 403 Forbidden reason, sends an alert notification, and spawns a background daemon thread (ws-reauth) that runs auth/auth_login.py --force, reloads the [.env](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), calls update_enctoken(), reconnects the WebSocket, and re-subscribes live options — all without requiring manual intervention.
on_reconnect: guards subscribe_live_options call with _kt.is_connected() to avoid spurious re-subscriptions during the 403 re-auth path.
connect() finally-block: fixed condition to use _kt.is_connected() instead of the stale self.connected flag.
[Makefile](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — minor ops additions
logs-1000 / server-logs-1000 targets for deeper log inspection.
server-start target to start the service (was missing alongside restart/stop).