### PR TITLE
fix: Zerodha WebSocket hardening + data pipeline bug fixes

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,70 @@
+# Virtual environment
+.venv/
+venv/
+env/
+
+# Python bytecode & cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.mypy_cache/
+.pytype/
+.pytest_cache/
+
+# IDE / editor settings
+.vscode/
+.idea/
+.cursor/
+.qodo/
+*.iml
+
+# Secrets & credentials
+.env
+.env.*
+!.env.template
+*.pem
+teleport_ls.txt
+
+# Git internals
+.git/
+
+# OS artefacts
+.DS_Store
+Thumbs.db
+
+# Jupyter checkpoints
+.ipynb_checkpoints/
+*.ipynb
+
+# Logs
+logs/
+*.log
+
+# Generated stock data — large binary datasets, not source code
+data/stocks/
+data/processed/
+data/raw/
+data/indices/
+data/backtest_results/
+
+# Trained model artefacts
+data/models/
+*.pkl
+*.joblib
+
+# Parquet files (binary data)
+*.parquet
+
+# CSV data exports
+data/processed/reports/
+data/backtest_results/
+
+# CocoIndex (vector index cache)
+.cocoindex_code/
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ help:
 	@echo "    server-logs-500     Tail last 500 lines of stock_monitor.log on server"
 	@echo "    server-logs-1000    Tail last 1000 lines of stock_monitor.log on server"
 	@echo "    server-logs-follow  Live-follow stock_monitor.log on server"
+	@echo "    server-logs-copy    Copy stock_monitor.log from server to local logs/"
 	@echo "    server-status       Show stock_analysis.service status"
 	@echo "    server-start        Start stock_analysis.service"
 	@echo "    server-restart      Restart stock_analysis.service"
@@ -285,6 +286,11 @@ server-logs-1000:
 .PHONY: server-logs-follow
 server-logs-follow:
 	ssh $(SERVER) "tail -f $(SERVER_LOG)"
+
+.PHONY: server-logs-copy
+server-logs-copy:
+	scp $(SERVER):$(SERVER_LOG) logs/stock_monitor.log
+	@echo "Copied to logs/stock_monitor.log"
 
 .PHONY: server-status
 server-status:

--- a/analyser/MessageFormatter.py
+++ b/analyser/MessageFormatter.py
@@ -318,6 +318,33 @@ def _fmt_pvo(data, trend):
     return [_pvo_line(d) for d in items]
 
 
+@MessageFormatter.register("FUTURE_OI_TREND")
+def _fmt_future_oi_trend(data, trend):
+    e = "📈" if trend == "BULLISH" else "📉"
+    line = f"  Futures OI Trend: {e} <b>{data.action}</b>"
+    parts = [f"OI 10d={data.oi_chg_10d:+.1f}%"]
+    if data.oi_chg_20d is not None:
+        parts.append(f"20d={data.oi_chg_20d:+.1f}%")
+    parts.append(f"Price 10d={data.price_chg_10d:+.1f}%")
+    if data.price_chg_20d is not None:
+        parts.append(f"20d={data.price_chg_20d:+.1f}%")
+    line += f" <code>{' | '.join(parts)}</code>"
+    return [line]
+
+
+@MessageFormatter.register("FUTURE_COST_OF_CARRY")
+def _fmt_future_coc(data, trend):
+    e = "⚠️" if data.action == "BACKWARDATION" else ("🔥" if data.action == "HIGH_COST_OF_CARRY" else "📊")
+    line = f"  Cost of Carry: {e} <b>{data.action}</b>"
+    parts = [f"basis={data.basis_pct:+.2f}%"]
+    if data.ann_coc is not None:
+        parts.append(f"ann_coc={data.ann_coc:.1f}%")
+    if data.days_to_expiry is not None:
+        parts.append(f"expiry={data.days_to_expiry}d")
+    line += f" <code>{' | '.join(parts)}</code>"
+    return [line]
+
+
 # ── PCR ───────────────────────────────────────────────────────────────────────
 
 @MessageFormatter.register("PCR_EXTREME")

--- a/analyser/OIChainAnalyser.py
+++ b/analyser/OIChainAnalyser.py
@@ -1183,8 +1183,8 @@ class OIChainAnalyser(BaseAnalyzer):
             ))
             logger.info(
                 f"[OI_SHIFT] {stock.stock_symbol} — SIGNAL {sentiment} | "
-                f"call_center={call_weighted_avg:.0f} ({call_shift}) "
-                f"put_center={put_weighted_avg:.0f} ({put_shift}) | {signal}"
+                f"call_center={call_center_str} "
+                f"put_center={put_center_str} | {signal}"
             )
             return True
 

--- a/common/Stock.py
+++ b/common/Stock.py
@@ -80,9 +80,13 @@ class Stock:
     def update_latest_data(self):
         valid_closes = self.priceData['Close'].dropna()
         if valid_closes.empty:
+            logger.warning(f"[Stock] No valid Close prices in priceData for {self.stock_symbol} — ltp not updated")
             return
         current_close = valid_closes.iloc[-1]
-        # previous_close = stock.priceData['Close'].iloc[-2]
+        if self.prevDayOHLCV is None:
+            logger.warning(f"[Stock] prevDayOHLCV not set for {self.stock_symbol} — ltp_change_perc will be 0")
+            self.ltp = current_close
+            return
         previous_close = self.prevDayOHLCV['CLOSE']
         change_percent = percentageChange(current_close, previous_close)
         self.ltp = current_close

--- a/common/logging_util.py
+++ b/common/logging_util.py
@@ -23,9 +23,13 @@ console_handler = logging.StreamHandler()
 console_handler.setLevel(_level)
 console_handler.setFormatter(logging.Formatter(LOG_FORMAT))
 
+# POSITIONAL=1 (set by the systemd positional service) → separate log file
+_is_positional = os.environ.get("POSITIONAL", "0") == "1" or os.environ.get("DEV_POSITIONAL", "0") == "1"
+_log_filename = "stock_monitor_positional.log" if _is_positional else "stock_monitor.log"
+
 # File handler — rotates at 10 MB, keeps last 5 files
 file_handler = RotatingFileHandler(
-    os.path.join(LOG_DIR, "stock_monitor.log"),
+    os.path.join(LOG_DIR, _log_filename),
     maxBytes=10 * 1024 * 1024,
     backupCount=5,
 )

--- a/fno/sensibull_adapter.py
+++ b/fno/sensibull_adapter.py
@@ -123,8 +123,8 @@ class SensibullAdapter:
                 if not leg:
                     continue
 
-                current_oi: int = leg.get("oi", 0)
-                oi_change_qty: int = leg.get("oi_change_quantity", 0)
+                current_oi: int = leg.get("oi") or 0
+                oi_change_qty: int = leg.get("oi_change_quantity") or 0
 
                 # Derive prev_oi: first call uses oi_change_quantity from Sensibull
                 # (absolute change since day-open); subsequent calls use cache
@@ -153,11 +153,11 @@ class SensibullAdapter:
                     index_stock.update_option_tick(strike, internal_side, greek_tick, merge=True)
                 else:
                     tick = {
-                        "last_price":           leg.get("last_price", 0),
+                        "last_price":           leg.get("last_price") or 0,
                         "oi":                   current_oi,
-                        "volume_traded":        leg.get("volume", 0),
-                        "total_buy_quantity":   leg.get("best_buy_price", 0),
-                        "total_sell_quantity":  leg.get("best_sell_price", 0),
+                        "volume_traded":        leg.get("volume") or 0,
+                        "total_buy_quantity":   leg.get("best_buy_price") or 0,
+                        "total_sell_quantity":  leg.get("best_sell_price") or 0,
                         "delta":    delta,
                         "gamma":    gamma,
                         "theta":    theta,

--- a/intraday/intraday_monitor.py
+++ b/intraday/intraday_monitor.py
@@ -469,13 +469,22 @@ def update_zerodha_option_chain(stockName = None, indexName = None):
                      f"options count: {len(index_options[index_options['expiry'] == expiry_dates[0]])}")
 
         zerodha_ctx["option_chain"]["current"] = index_options[index_options['expiry'] == expiry_dates[0]]
-        zerodha_ctx["futures_mdata"]["current"] = index_futures[index_futures['expiry'] == expiry_dates[0]]
         if len(expiry_dates) > 1:
             zerodha_ctx["option_chain"]["next"] = index_options[index_options['expiry'] == expiry_dates[1]]
-            zerodha_ctx["futures_mdata"]["next"] = index_futures[index_futures['expiry'] == expiry_dates[1]]
         else:
             logger.info(f"Index {index.stock_symbol} next expiry not available")
             zerodha_ctx["option_chain"]["next"] = pd.DataFrame()
+
+        # Futures may have different expiry cadence than options (e.g. SENSEX: weekly options,
+        # monthly futures) — use futures' own nearest expiry dates instead of option expiry dates.
+        futures_expiry_dates = sorted(index_futures['expiry'].unique())
+        if futures_expiry_dates:
+            zerodha_ctx["futures_mdata"]["current"] = index_futures[index_futures['expiry'] == futures_expiry_dates[0]]
+            zerodha_ctx["futures_mdata"]["next"] = index_futures[index_futures['expiry'] == futures_expiry_dates[1]] if len(futures_expiry_dates) > 1 else pd.DataFrame()
+        else:
+            zerodha_ctx["futures_mdata"]["current"] = pd.DataFrame()
+            zerodha_ctx["futures_mdata"]["next"] = pd.DataFrame()
+            logger.warning(f"No futures found for index {index.stock_symbol}")
 
         # Register option and futures tokens in the registry (current expiry only for live ticks)
         current_options = index_options[index_options['expiry'] == expiry_dates[0]]

--- a/notification/Notification.py
+++ b/notification/Notification.py
@@ -132,6 +132,7 @@ class TELEGRAM_NOTIFICATIONS:
                 except Exception as e:
                     logger.error(f"Telegram send failed: {e}")
                     return False
+            return False  # all retry attempts exhausted
 
         return True
 

--- a/notification/bot_listener.py
+++ b/notification/bot_listener.py
@@ -1,4 +1,6 @@
+import time
 from telegram.ext import ApplicationBuilder
+from telegram.error import NetworkError, TimedOut
 from common.constants import TELEGRAM_INTRADAY_TOKEN
 from common.logging_util import logger
 from notification.commands import register_all
@@ -42,7 +44,22 @@ def init_telegram_bot():
         )
         logger.info("LLM budget alert job scheduled (every 15 min)")
 
-    _application.run_polling()
+    _retry_run_polling()
+
+
+def _retry_run_polling() -> None:
+    delay = 10
+    while True:
+        try:
+            _application.run_polling()
+            return  # clean exit (stop_running() was called)
+        except (NetworkError, TimedOut) as e:
+            logger.error(f"[bot] Telegram polling network error: {e} — retrying in {delay}s")
+            time.sleep(delay)
+            delay = min(delay * 2, 300)  # cap at 5 minutes
+        except Exception as e:
+            logger.error(f"[bot] Telegram polling fatal error: {e} — not retrying")
+            return
 
 
 def stop_telegram_bot():

--- a/tests/analyser/test_futures_analyser.py
+++ b/tests/analyser/test_futures_analyser.py
@@ -179,12 +179,12 @@ class TestResetConstants:
         with patch("common.shared.app_ctx", _positional_ctx()):
             a = FuturesAnalyser()
             a.reset_constants()
-            assert FuturesAnalyser.FUTURE_OI_INCREASE_PERCENTAGE == 10
-            assert FuturesAnalyser.FUTURE_PRICE_CHANGE_PERCENTAGE == 2
+            assert FuturesAnalyser.FUTURE_OI_INCREASE_PERCENTAGE == 3.0
+            assert FuturesAnalyser.FUTURE_PRICE_CHANGE_PERCENTAGE == 1.0
 
     def test_intraday_thresholds(self):
         with patch("common.shared.app_ctx", _intraday_ctx()):
             a = FuturesAnalyser()
             a.reset_constants()
-            assert FuturesAnalyser.FUTURE_OI_INCREASE_PERCENTAGE == 0.5
-            assert FuturesAnalyser.FUTURE_PRICE_CHANGE_PERCENTAGE == 0.5
+            assert FuturesAnalyser.FUTURE_OI_INCREASE_PERCENTAGE == 0.10
+            assert FuturesAnalyser.FUTURE_PRICE_CHANGE_PERCENTAGE == 0.15

--- a/tests/notification/test_notification.py
+++ b/tests/notification/test_notification.py
@@ -61,14 +61,11 @@ class TestSendNotification:
         ok_resp = MagicMock()
         ok_resp.status_code = 200
 
-        with patch("notification.Notification.requests.post",
+        with patch("notification.Notification.NOTIFICATION_CHANNEL", "telegram"), \
+             patch("notification.Notification.requests.post",
                    side_effect=[fail_resp, ok_resp]) as mock_post, \
-             patch("notification.Notification.time.sleep" if hasattr(
-                 __import__("notification.Notification", fromlist=["Notification"]),
-                 "time") else "time.sleep"):
-            # patch sleep to avoid slowing tests
-            with patch("time.sleep"):
-                result = TELEGRAM_NOTIFICATIONS.send_notification("hello")
+             patch("time.sleep"):
+            result = TELEGRAM_NOTIFICATIONS.send_notification("hello")
 
         assert result is True
         assert mock_post.call_count == 2
@@ -80,7 +77,8 @@ class TestSendNotification:
         fail_resp.status_code = 500
         fail_resp.text = "Server Error"
 
-        with patch("notification.Notification.requests.post",
+        with patch("notification.Notification.NOTIFICATION_CHANNEL", "telegram"), \
+             patch("notification.Notification.requests.post",
                    return_value=fail_resp), \
              patch("time.sleep"):
             result = TELEGRAM_NOTIFICATIONS.send_notification("hello")
@@ -94,7 +92,8 @@ class TestSendNotification:
         ok_resp = MagicMock()
         ok_resp.status_code = 200
 
-        with patch("notification.Notification.requests.post",
+        with patch("notification.Notification.NOTIFICATION_CHANNEL", "telegram"), \
+             patch("notification.Notification.requests.post",
                    side_effect=[
                        req_lib.Timeout,
                        req_lib.Timeout,
@@ -109,7 +108,8 @@ class TestSendNotification:
         import requests as req_lib
         _set_production(1)
 
-        with patch("notification.Notification.requests.post",
+        with patch("notification.Notification.NOTIFICATION_CHANNEL", "telegram"), \
+             patch("notification.Notification.requests.post",
                    side_effect=req_lib.ConnectionError), \
              patch("time.sleep"):
             result = TELEGRAM_NOTIFICATIONS.send_notification("hello")
@@ -122,7 +122,8 @@ class TestSendNotification:
         ok_resp = MagicMock()
         ok_resp.status_code = 200
 
-        with patch("notification.Notification.requests.post",
+        with patch("notification.Notification.NOTIFICATION_CHANNEL", "telegram"), \
+             patch("notification.Notification.requests.post",
                    return_value=ok_resp) as mock_post:
             TELEGRAM_NOTIFICATIONS.send_notification("bold text", parse_mode="HTML")
 
@@ -136,7 +137,8 @@ class TestSendNotification:
         ok_resp = MagicMock()
         ok_resp.status_code = 200
 
-        with patch("notification.Notification.requests.post",
+        with patch("notification.Notification.NOTIFICATION_CHANNEL", "telegram"), \
+             patch("notification.Notification.requests.post",
                    return_value=ok_resp) as mock_post:
             TELEGRAM_NOTIFICATIONS.send_notification("plain text")
 

--- a/zerodha/futures_fetcher.py
+++ b/zerodha/futures_fetcher.py
@@ -141,7 +141,7 @@ class FuturesFetcher:
                 spot_map[day_key] = float(row.get("Close", row.get("close", 0)) or 0)
 
         futures_data_current = pd.DataFrame()
-        if futures_mdata_current is not None:
+        if futures_mdata_current is not None and not futures_mdata_current.empty:
             token = futures_mdata_current["instrument_token"].values[0]
             hist_data = _fetch_with_retry(token)
             if hist_data:
@@ -150,9 +150,11 @@ class FuturesFetcher:
                     f"Futures data for {stock.stock_symbol} (current expiry) "
                     f"fetched for {len(futures_data_current)} rows."
                 )
+            else:
+                logger.warning(f"[FuturesFetcher] No futures data returned for {stock.stock_symbol} (current expiry token={token})")
 
         futures_data_next = pd.DataFrame()
-        if is_next_expiry_required and futures_mdata_next is not None:
+        if is_next_expiry_required and futures_mdata_next is not None and not futures_mdata_next.empty:
             token_next = futures_mdata_next["instrument_token"].values[0]
             hist_data_next = _fetch_with_retry(token_next)
             if hist_data_next:
@@ -161,6 +163,8 @@ class FuturesFetcher:
                     f"Futures data for {stock.stock_symbol} (next expiry) "
                     f"fetched for {len(futures_data_next)} rows."
                 )
+            else:
+                logger.warning(f"[FuturesFetcher] No futures data returned for {stock.stock_symbol} (next expiry token={token_next})")
 
         zerodha_ctx["futures_data"]["current"] = futures_data_current
         zerodha_ctx["futures_data"]["next"] = futures_data_next
@@ -211,6 +215,10 @@ class FuturesFetcher:
                         f"C={row['close']:.2f} vol={row['volume']:,} oi={row.get('oi', 0):,} "
                         f"spot={float(row.get('underlying_price') or 0):.2f}"
                     )
+                else:
+                    logger.warning(f"[FuturesFetcher] No intraday candle matched at {dt} for {stock.stock_symbol} (current expiry token={token})")
+            else:
+                logger.warning(f"[FuturesFetcher] No intraday futures data returned for {stock.stock_symbol} (current expiry token={token}, dt={dt})")
 
         # ── Next expiry ───────────────────────────────────────────────────
         futures_data_next = zerodha_ctx["futures_data"]["next"]
@@ -225,12 +233,17 @@ class FuturesFetcher:
                     ts, interval,
                     dt_fmt="%Y-%m-%d %H:%M:%S",
                 )
+                if not hist_data_next:
+                    logger.warning(f"[FuturesFetcher] No intraday futures data returned for {stock.stock_symbol} (next expiry token={token_next}, ts={ts})")
+                    continue
                 if hist_data_next:
                     candle_next = next(
                         (c for c in hist_data_next
                          if pd.Timestamp(c["date"]).tz_convert("Asia/Kolkata") == ts),
                         None,
                     )
+                    if candle_next is None:
+                        logger.warning(f"[FuturesFetcher] No intraday candle matched at {ts} for {stock.stock_symbol} (next expiry token={token_next})")
                     if candle_next:
                         row_next = self._candle_to_row(
                             candle_next, ts, candle_next["close"]

--- a/zerodha/tick_store.py
+++ b/zerodha/tick_store.py
@@ -17,6 +17,8 @@ import threading
 import time
 from typing import Optional
 
+from common.logging_util import logger
+
 
 class TickStore:
     """Thread-safe container for live WebSocket tick data."""
@@ -132,6 +134,7 @@ class TickStore:
                 # Enrichment-only: only update existing strikes (Zerodha-subscribed)
                 existing = self.options_live.get(strike, {}).get(option_type)
                 if existing is None:
+                    logger.debug(f"[TickStore] Enrichment skip: strike {strike} {option_type} not in options_live (Zerodha not yet subscribed)")
                     return
                 existing.update(tick)
                 return

--- a/zerodha/zerodha_analysis.py
+++ b/zerodha/zerodha_analysis.py
@@ -28,15 +28,19 @@ class ZerodhaTickerManager:
         self.root = "wss://ws.zerodha.com"
         self.connected = False
         self._kt: KiteTicker | None = None
-        self.max_retries = 3
+        self.max_retries = 50
         self.retry_delay = 5  # seconds
-        self.tick_queue = queue.Queue()
+        self.tick_queue = queue.Queue(maxsize=2000)
         self.processor_thread = None
         self.stop_processor = False
         self.notification_cooldown = 300  # 5 minutes cooldown
         self.last_notification_time = defaultdict(float)
         self.is_enctoken_updated = False
         self.reconnect_attempts = 0
+        self._unknown_tokens: set = set()  # suppress repeated warnings for same token
+        self._reauth_lock = threading.Lock()
+        self._is_reauthing = False
+        self._tick_count = 0  # for queue depth logging
 
         # Track last ATM per symbol for re-centering decisions
         self._last_atm: dict = {}
@@ -58,12 +62,13 @@ class ZerodhaTickerManager:
         return shared.app_ctx.token_registry
 
     def initialize_kite_ticker(self):
-        self._kt = KiteTicker(self.apiKey, self.username, self.encToken, root=self.root, reconnect=True, reconnect_max_tries=self.max_retries)
+        self._kt = KiteTicker(self.apiKey, self.username, self.encToken, root=self.root, reconnect=True, reconnect_max_tries=self.max_retries, reconnect_max_delay=60)
         self._kt.on_connect = self.on_connect
         self._kt.on_close = self.on_close
         self._kt.on_error = self.on_error
         self._kt.on_ticks = self.on_ticks
         self._kt.on_reconnect = self.on_reconnect
+        self._kt.on_noreconnect = self.on_noreconnect
 
     def connect(self):
         try:
@@ -78,15 +83,15 @@ class ZerodhaTickerManager:
                     logger.info("Successfully connected to Zerodha WebSocket")
                     return True
                 time.sleep(0.5)
+
+            logger.error("Failed to connect to Zerodha WebSocket after timeout")
+            self.close_connection()
+            return False
         except Exception as e:
             logger.error(f"Error while connecting to Zerodha WebSocket: {str(e)}")
             self.connected = False
             self.is_enctoken_updated = False
             return False
-        finally:
-            if not (self._kt and self._kt.is_connected()):
-                logger.error("Failed to connect to Zerodha WebSocket after multiple attempts")
-                self.close_connection()
 
     def close_connection(self):
         if self._kt:
@@ -138,11 +143,18 @@ class ZerodhaTickerManager:
     # ─── Tick Processing ────────────────────────────────────────────────
 
     def start_tick_processor(self):
+        if self.processor_thread and self.processor_thread.is_alive():
+            return  # already running — idempotent
         self.stop_processor = False
         self.processor_thread = threading.Thread(target=self.process_ticks, daemon=True)
         self.processor_thread.start()
 
+    def signal_tick_processor_stop(self):
+        """Signal the processor thread to stop — non-blocking, safe to call from reactor thread."""
+        self.stop_processor = True
+
     def stop_tick_processor(self):
+        """Signal stop and wait for the processor thread to drain — only use during clean shutdown."""
         self.stop_processor = True
         if self.processor_thread:
             self.processor_thread.join(timeout=5)
@@ -152,6 +164,9 @@ class ZerodhaTickerManager:
             try:
                 tick = self.tick_queue.get(timeout=1)
                 self._route_tick(tick)
+                self._tick_count += 1
+                if self._tick_count % 500 == 0:
+                    logger.debug(f"[ZerodhaWS] processed {self._tick_count} ticks, queue depth={self.tick_queue.qsize()}")
             except queue.Empty:
                 continue
             except Exception as e:
@@ -202,6 +217,9 @@ class ZerodhaTickerManager:
         """Handle equity/index/commodity tick — update _zerodha_data."""
         parent = self._get_parent_object(info)
         if parent is None:
+            if info.token not in self._unknown_tokens:
+                self._unknown_tokens.add(info.token)
+                logger.warning(f"[ZerodhaWS] No parent object for equity token {info.token} ({info.parent_symbol}) — tick dropped")
             return
         parent.update_zerodha_data(tick)
 
@@ -228,6 +246,9 @@ class ZerodhaTickerManager:
         """Handle option tick — update parent's options_live data."""
         parent = self._get_parent_object(info)
         if parent is None:
+            if info.token not in self._unknown_tokens:
+                self._unknown_tokens.add(info.token)
+                logger.warning(f"[ZerodhaWS] No parent object for option token {info.token} ({info.parent_symbol} {info.strike} {info.option_type}) — tick dropped")
             return
 
         parent.update_option_tick(info.strike, info.option_type, tick)
@@ -256,6 +277,9 @@ class ZerodhaTickerManager:
         """Handle futures tick — update parent's futures_live data."""
         parent = self._get_parent_object(info)
         if parent is None:
+            if info.token not in self._unknown_tokens:
+                self._unknown_tokens.add(info.token)
+                logger.warning(f"[ZerodhaWS] No parent object for futures token {info.token} ({info.parent_symbol}) — tick dropped")
             return
 
         expiry_key = "current" if info.expiry == self._get_current_expiry(info.parent_symbol) else "next"
@@ -266,6 +290,25 @@ class ZerodhaTickerManager:
         if shared.app_ctx.stockExpires:
             return shared.app_ctx.stockExpires[0]
         return None
+
+    # ─── Thread-safe WS send helper ───────────────────────────────────
+
+    def _ws_call(self, fn, *args):
+        """Call a KiteTicker send method safely from any thread.
+
+        Twisted's sendMessage is only safe on the reactor thread.
+        This marshals the call via reactor.callFromThread when the reactor
+        is running (processor thread / analysis thread context).
+        Falls back to direct call during tests or when reactor is not started.
+        """
+        try:
+            from twisted.internet import reactor as _reactor
+            if _reactor.running:
+                _reactor.callFromThread(fn, *args)
+            else:
+                fn(*args)
+        except Exception as e:
+            logger.error(f"[ZerodhaWS] _ws_call failed for {fn.__name__}: {e}")
 
     # ─── Dynamic Re-centering ──────────────────────────────────────────
 
@@ -294,23 +337,14 @@ class ZerodhaTickerManager:
         )
 
         if unsub and self._kt and self._kt.is_connected():
-            try:
-                self._kt.unsubscribe(unsub)
-            except Exception as e:
-                logger.error(f"Error unsubscribing during recenter: {e}")
+            self._ws_call(self._kt.unsubscribe, unsub)
 
         if new_sub and self._kt and self._kt.is_connected():
-            try:
-                self._kt.subscribe(new_sub)
-            except Exception as e:
-                logger.error(f"Error subscribing during recenter: {e}")
+            self._ws_call(self._kt.subscribe, new_sub)
 
         for ws_mode, tokens in mode_changes.items():
             if tokens and self._kt and self._kt.is_connected():
-                try:
-                    self._kt.set_mode(ws_mode, tokens)
-                except Exception as e:
-                    logger.error(f"Error setting mode {ws_mode} during recenter: {e}")
+                self._ws_call(self._kt.set_mode, ws_mode, tokens)
 
     def subscribe_options_for_symbol(self, parent_symbol: str, spot_price: float):
         """
@@ -334,14 +368,11 @@ class ZerodhaTickerManager:
             return
 
         if self._kt and self._kt.is_connected():
-            try:
-                self._kt.subscribe(subscribe_tokens)
-                for ws_mode, tokens in mode_map.items():
-                    self._kt.set_mode(ws_mode, tokens)
-                self._last_atm[parent_symbol] = registry.round_to_strike(spot_price, parent_symbol)
-                logger.info(f"Subscribed {len(subscribe_tokens)} option tokens for {parent_symbol}")
-            except Exception as e:
-                logger.error(f"Error subscribing options for {parent_symbol}: {e}")
+            self._ws_call(self._kt.subscribe, subscribe_tokens)
+            for ws_mode, tokens in mode_map.items():
+                self._ws_call(self._kt.set_mode, ws_mode, tokens)
+            self._last_atm[parent_symbol] = registry.round_to_strike(spot_price, parent_symbol)
+            logger.info(f"Subscribed {len(subscribe_tokens)} option tokens for {parent_symbol}")
 
     # ─── Live Options Subscription ────────────────────────────────────
 
@@ -472,11 +503,11 @@ class ZerodhaTickerManager:
     def on_close(self, ws, code, reason):
         self.connected = False
         logger.info(f"Connection closed. Code: {code}, Reason: {reason}")
-        self.stop_tick_processor()
+        self.signal_tick_processor_stop()
 
     def on_error(self, ws, code, reason):
         logger.error(f"Error in connection. Code: {code}, Reason: {reason}")
-        self.stop_tick_processor()
+        self.signal_tick_processor_stop()
         # 403 = enctoken expired — alert and trigger a fresh login in a background thread.
         # The auth script writes the new token to .env; the next reconnect attempt picks it up.
         if "403" in str(reason):
@@ -487,9 +518,18 @@ class ZerodhaTickerManager:
                 "Attempting automatic re-login via auth_login.py…",
                 parse_mode="HTML",
             )
-            import threading
             def _reauth():
+                if not self._reauth_lock.acquire(blocking=False):
+                    logger.warning("[ZerodhaWS] re-auth already in progress — skipping duplicate")
+                    return
+                self._is_reauthing = True
                 try:
+                    # Kill the old factory's reconnect loop before building a new ticker
+                    if self._kt:
+                        try:
+                            self._kt.stop_retry()
+                        except Exception:
+                            pass
                     import subprocess, sys, os
                     script = os.path.join(os.path.dirname(os.path.dirname(__file__)), "auth", "auth_login.py")
                     result = subprocess.run(
@@ -498,7 +538,6 @@ class ZerodhaTickerManager:
                     )
                     if result.returncode == 0:
                         logger.info("[ZerodhaWS] re-auth succeeded — new enctoken written to .env")
-                        # Reload the new token and reconnect
                         from dotenv import load_dotenv
                         load_dotenv(override=True)
                         import common.constants as _c
@@ -517,6 +556,9 @@ class ZerodhaTickerManager:
                         )
                 except Exception as e:
                     logger.error(f"[ZerodhaWS] re-auth exception: {e}")
+                finally:
+                    self._is_reauthing = False
+                    self._reauth_lock.release()
             threading.Thread(target=_reauth, name="ws-reauth", daemon=True).start()
 
     def on_ticks(self, ws, ticks):
@@ -525,11 +567,28 @@ class ZerodhaTickerManager:
         logger.debug(f"Received {len(ticks)} ticks")
         shared.app_ctx.last_equity_tick_time = time.time()
         for tick in ticks:
-            self.tick_queue.put(tick)
+            try:
+                self.tick_queue.put_nowait(tick)
+            except queue.Full:
+                logger.warning(f"[ZerodhaWS] tick_queue full (maxsize=2000) — dropping tick for token {tick.get('instrument_token')}")
 
     def on_reconnect(self, ws, attempts_count):
         self.reconnect_attempts = attempts_count
         logger.info(f"Reconnected to Zerodha WebSocket. Attempt: {self.reconnect_attempts}")
+
+    def on_noreconnect(self, ws):
+        self.connected = False
+        logger.error(f"[ZerodhaWS] All {self.max_retries} reconnect attempts exhausted — WebSocket permanently disconnected")
+        try:
+            from notification.Notification import TELEGRAM_NOTIFICATIONS
+            TELEGRAM_NOTIFICATIONS.send_notification(
+                f"🚨 <b>Zerodha WS DEAD</b> — {self.max_retries} reconnect attempts exhausted.\n"
+                "Live tick data has stopped. Session is running on stale data.\n"
+                "Process will restart at next market open (systemd).",
+                parse_mode="HTML",
+            )
+        except Exception:
+            pass
         # Only re-subscribe options if this looks like a genuine reconnect (not a 403 loop).
         # The 403 re-auth path in on_error handles subscription after token refresh.
         if self.live_options_engine is not None and self._kt and self._kt.is_connected():


### PR DESCRIPTION
## Summary

- **WebSocket hardening**: single-flight re-auth guard, `on_noreconnect` alert, non-blocking reactor callbacks, thread-safe `sendMessage` marshalling, bounded tick queue, fixed `connect()` finally bug
- **Data pipeline bug fixes**: SENSEX futures crash, `OIChainAnalyser` NoneType format error, missing `MessageFormatter` formatters, `Notification.py` returning `True` after retry exhaustion
- **Logging improvements**: warn on empty fetch responses across futures, options, and stock price data
- **Test fixes**: stale threshold assertions updated, notification tests pin `NOTIFICATION_CHANNEL=telegram`

## Key changes in `zerodha/zerodha_analysis.py`
- Single-flight re-auth with lock — stops orphaned KiteTicker factory storm on repeated 403s
- `stop_retry()` called on old ticker before building new one during re-auth
- `on_noreconnect` wired — CRITICAL alert when all 50 retries exhausted (was silent)
- `signal_tick_processor_stop()` in `on_close`/`on_error` — stops blocking Twisted reactor thread
- `_ws_call()` marshals subscribe/unsubscribe/set_mode via `reactor.callFromThread` — thread-safe
- `connect()` `finally` bug fixed — was closing healthy connections on return True
- `tick_queue(maxsize=2000)` with `put_nowait` drop — prevents OOM on queue buildup
- `start_tick_processor()` is now idempotent
- `max_retries: 3 → 50`, `reconnect_max_delay=60`

## Bug fixes
- `zerodha/futures_fetcher.py`: guard empty `futures_mdata` before `iloc[0]` (SENSEX crash)
- `intraday/intraday_monitor.py`: SENSEX index futures use own expiry cadence (monthly) not weekly option expiry
- `analyser/OIChainAnalyser.py`: fix NoneType format crash when `put_weighted_avg` is None
- `analyser/MessageFormatter.py`: add missing `FUTURE_OI_TREND` and `FUTURE_COST_OF_CARRY` formatters
- `notification/Notification.py`: fix `send_notification` returning `True` after all Telegram retries exhausted
- `notification/bot_listener.py`: retry `run_polling` on `NetworkError` with exponential backoff

## Logging
- `zerodha/futures_fetcher.py`: warn when API returns empty data (positional + intraday)
- `zerodha/zerodha_analysis.py`: warn once per unknown token (dropped tick)
- `zerodha/tick_store.py`: debug log on enrichment-only skip
- `common/Stock.py`: warn on empty closes and missing `prevDayOHLCV`
- `common/logging_util.py`: `POSITIONAL=1` routes to `stock_monitor_positional.log`

## Other
- `Makefile`: `server-logs-copy` target (scp server log to local)

## Test plan
- [ ] `make test-fast` passes
- [ ] Deploy and observe reconnect behaviour in next market session
- [ ] Verify `on_noreconnect` CRITICAL alert fires when retries exhausted
- [ ] Confirm no duplicate log lines after systemd service update

🤖 Generated with [Claude Code](https://claude.com/claude-code)