### PR TITLE
Phase 1B: Extract notification-service — Redis stream dispatch + per-service logging

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -34,6 +34,8 @@ ENABLE_LIVE_OPTIONS=0
 LIVE_OPTIONS_ONLY=0
 ENABLE_INTELLIGENCE=0
 ENABLE_NARRATOR=0
+# REDIS_URL — required for notification-service dispatch. Default: redis://localhost:6379
+# REDIS_URL=redis://localhost:6379
 
 # Options data source:
 #   "zerodha"   — Zerodha WebSocket only. Tick-accurate OI, bid/ask depth, OHLC.

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,14 @@ help:
 	@echo ""
 	@echo "  Run"
 	@echo "    run-prod           Intraday monitor — PRODUCTION=1"
-	@echo "    run-dev            Dev intraday — PRODUCTION=0 DEV_INTRADAY=1"
+	@echo "    run-dev            Dev intraday + notification service (auto start+stop)"
 	@echo "    run-dev-positional Dev positional (EOD) — PRODUCTION=0 DEV_POSITIONAL=1"
 	@echo "                       Append DEV_NOTIFY=1 to either run-dev target to send Telegram alerts in dev mode"
 	@echo "    run-dev-stock-intraday   Dev single stock intraday:   make run-dev-stock-intraday STOCK=RELIANCE"
 	@echo "    run-dev-stock-positional Dev single stock positional: make run-dev-stock-positional STOCK=RELIANCE"
 	@echo "    run-dev-index-intraday   Dev single index intraday:   make run-dev-index-intraday INDEX=NIFTY"
 	@echo "    run-dev-index-positional Dev single index positional: make run-dev-index-positional INDEX=NIFTY"
+	@echo "    run-dev-stop       Stop notification service (auto-stops with Ctrl+C on run-dev)"
 	@echo "    run-premarket      Global cues + pre-open reports (--premarket shortcut)"
 	@echo "    run-postmarket     Post-market analysis pipeline"
 	@echo "    deploy             Deploy to EC2 via SSH"
@@ -50,11 +51,16 @@ help:
 	@echo ""
 	@echo "  Maintenance"
 	@echo "    update-derivatives  Refresh final_derivatives_list.json from Zerodha + NSE"
-	@echo "    logs          Tail stock_monitor.log (last 50 lines)"
+	@echo "    logs          Monolith log — tail stock_monitor.log (legacy)"
 	@echo "    logs-500      Tail stock_monitor.log (last 500 lines)"
 	@echo "    logs-1000     Tail stock_monitor.log (last 1000 lines)"
 	@echo "    logs-follow   Follow stock_monitor.log live"
 	@echo "    logs-grep     Grep stock_monitor.log: make logs-grep Q=RELIANCE"
+	@echo "    logs-all      View last 20 lines of every service log"
+	@echo "    logs-all-follow  Follow all service logs live"
+	@echo "    logs-svc      View one service: make logs-svc SVC_LOG=data-gateway"
+	@echo "    logs-svc-follow  Follow one service live"
+	@echo "    logs-service  List all available service logs"
 	@echo "    clean         Remove __pycache__, .pyc, pytest cache"
 	@echo "    clean-all     clean + remove .venv"
 	@echo ""
@@ -71,11 +77,35 @@ help:
 	@echo "    server-stop         Stop stock_analysis.service"
 	@echo "    server-pull         git pull on server repo"
 	@echo "    server-df           Disk usage on server"
+	@echo "    server-redis-status     Redis status + memory on server"
+	@echo "    server-redis-start      Start Redis on server"
+	@echo "    server-redis-stop       Stop Redis on server"
+	@echo "    server-redis-restart    Restart Redis on server"
+	@echo "    server-redis-config     Apply Redis config on server"
+	@echo "    server-notification-start     Start notification service on server"
+	@echo "    server-notification-stop      Stop notification service on server"
+	@echo "    server-notification-status    Notification service status + dead letters"
+	@echo "    server-notification-logs      Notification service logs on server"
+	@echo "    server-notify-test       Send test notification via server Redis"
+	@echo "    server-dead-letter       View dead letters on server"
+	@echo "    server-svcs-status       All StockAnalysis service statuses"
 	@echo "    update-enctoken     Update ZERODHA_ENC_TOKEN on server .env:"
 	@echo "                          make update-enctoken TOKEN=<your_enc_token>"
 	@echo "    auth-run            Run auth_login.py locally (skips if already ran today)"
 	@echo "    auth-force          Force-refresh enctoken locally (bypasses once-per-day guard)"
 	@echo "    server-auth-force   Force-refresh enctoken on server"
+	@echo ""
+	@echo "  Redis"
+	@echo "    redis-install  Install Redis via Homebrew"
+	@echo "    redis-start    Start Redis service"
+	@echo "    redis-stop     Stop Redis service"
+	@echo "    redis-restart  Restart Redis service"
+	@echo "    redis-status   Check Redis status + memory usage"
+	@echo "    redis-cli      Open interactive Redis CLI"
+	@echo "    redis-config   Apply production config (128MB, LRU, no persistence)"
+	@echo ""
+	@echo "  Services"
+	@echo "    run-notification       Start notification service (stream consumer)"
 	@echo "────────────────────────────────────────────────────────────"
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -112,7 +142,43 @@ env-check:
 	    grep -q "^$$var=.\+" .env || \
 	        { echo "WARNING: $$var is not set in .env"; }; \
 	done
+	@grep -q "^REDIS_URL=" .env 2>/dev/null || echo "WARNING: REDIS_URL is not set in .env (defaults to redis://localhost:6379)"
 	@echo "env-check complete."
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Redis
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: redis-install redis-start redis-stop redis-restart redis-status redis-cli redis-config
+
+redis-install:
+	@which redis-server >/dev/null 2>&1 && echo "Redis is already installed ($(shell redis-cli --version))" || brew install redis
+
+redis-start:
+	brew services start redis
+	@sleep 1
+	@redis-cli ping || echo "Redis failed to start"
+
+redis-stop:
+	brew services stop redis
+
+redis-restart:
+	brew services restart redis
+	@sleep 1
+	@redis-cli ping || echo "Redis failed to restart"
+
+redis-status:
+	@redis-cli ping 2>/dev/null && echo "Redis: RUNNING" || echo "Redis: NOT RUNNING"
+	@redis-cli INFO server 2>/dev/null | grep redis_version
+	@redis-cli INFO memory 2>/dev/null | grep used_memory_human
+
+redis-cli:
+	redis-cli
+
+redis-config:
+	redis-cli CONFIG SET maxmemory 128mb
+	redis-cli CONFIG SET maxmemory-policy allkeys-lru
+	redis-cli CONFIG SET save ""
+	@redis-cli CONFIG GET maxmemory maxmemory-policy save
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Run
@@ -121,13 +187,61 @@ env-check:
 run-prod:
 	PRODUCTION=1 PYTHONPATH=$(CURDIR) $(PYTHON) intraday/intraday_monitor.py
 
+NOTIFICATION_PID_FILE := .notification.pid
+NOTIFICATION_LOG := logs/notification-service.log
+
 .PHONY: run-dev
 run-dev:
-	PRODUCTION=0 DEV_INTRADAY=1 PYTHONPATH=$(CURDIR) $(PYTHON) intraday/intraday_monitor.py
+	@echo "Starting notification service (background)..."
+	@mkdir -p logs
+	REDIS_URL=redis://localhost:6379 PYTHONPATH=$(CURDIR) nohup $(PYTHON) \
+		services/notification-service/main.py --consumer-name dev-1 \
+		> /dev/null 2>$(NOTIFICATION_LOG) & \
+		echo $$! > $(NOTIFICATION_PID_FILE)
+	@sleep 2
+	@if kill -0 $$(cat $(NOTIFICATION_PID_FILE) 2>/dev/null) 2>/dev/null; then \
+		echo "Notification service started (pid $$(cat $(NOTIFICATION_PID_FILE)))."; \
+		echo "Starting intraday monitor... Ctrl+C to stop everything."; \
+	else \
+		echo "Notification service failed. Check $(NOTIFICATION_LOG)"; \
+		exit 1; \
+	fi
+	@trap '' INT; \
+	PRODUCTION=0 DEV_INTRADAY=1 PYTHONPATH=$(CURDIR) $(PYTHON) intraday/intraday_monitor.py; \
+	EXIT_CODE=$$?; \
+	$(MAKE) run-dev-stop >/dev/null 2>&1; \
+	exit $$EXIT_CODE
 
 .PHONY: run-dev-positional
 run-dev-positional:
-	PRODUCTION=0 DEV_POSITIONAL=1 PYTHONPATH=$(CURDIR) $(PYTHON) intraday/intraday_monitor.py
+	@echo "Starting notification service (background)..."
+	@mkdir -p logs
+	REDIS_URL=redis://localhost:6379 PYTHONPATH=$(CURDIR) nohup $(PYTHON) \
+		services/notification-service/main.py --consumer-name dev-1 \
+		> /dev/null 2>$(NOTIFICATION_LOG) & \
+		echo $$! > $(NOTIFICATION_PID_FILE)
+	@sleep 2
+	@if kill -0 $$(cat $(NOTIFICATION_PID_FILE) 2>/dev/null) 2>/dev/null; then \
+		echo "Notification service started (pid $$(cat $(NOTIFICATION_PID_FILE)))."; \
+		echo "Running positional analysis..."; \
+	else \
+		echo "Notification service failed. Check $(NOTIFICATION_LOG)"; \
+		exit 1; \
+	fi
+	@trap '' INT; \
+	PRODUCTION=0 DEV_POSITIONAL=1 PYTHONPATH=$(CURDIR) $(PYTHON) intraday/intraday_monitor.py; \
+	EXIT_CODE=$$?; \
+	$(MAKE) run-dev-stop >/dev/null 2>&1; \
+	exit $$EXIT_CODE
+
+.PHONY: run-dev-stop
+run-dev-stop:
+	@if [ -f $(NOTIFICATION_PID_FILE) ]; then \
+		PID=$$(cat $(NOTIFICATION_PID_FILE)); \
+		echo "Stopping notification service (pid $$PID)..."; \
+		kill $$PID 2>/dev/null && echo "Stopped." || echo "Already stopped."; \
+		rm -f $(NOTIFICATION_PID_FILE); \
+	fi
 
 # Usage: make run-dev-stock-intraday STOCK=RELIANCE
 #        make run-dev-stock-positional STOCK=RELIANCE
@@ -156,8 +270,6 @@ run-dev-index-positional:
 	PRODUCTION=0 DEV_POSITIONAL=1 PYTHONPATH=$(CURDIR) $(PYTHON) intraday/intraday_monitor.py --index $(INDEX)
 
 .PHONY: run-premarket
-run-premarket:
-	PYTHONPATH=$(CURDIR) $(PYTHON) intraday/intraday_monitor.py --premarket
 
 .PHONY: run-postmarket
 run-postmarket:
@@ -247,6 +359,50 @@ logs-grep:
 	@test -n "$(Q)" || { echo "ERROR: Q is required. Usage: make logs-grep Q=RELIANCE"; exit 1; }
 	@grep -i "$(Q)" $(LOG_FILE) 2>/dev/null | tail -100 || echo "No matches for '$(Q)' in $(LOG_FILE)."
 
+# ─── Per-service log targets ──────────────────────────────────────────────────
+LOG_DIR := logs
+SVC_LOG ?= notification-service
+
+.PHONY: logs-all logs-all-follow logs-svc logs-svc-follow logs-service
+logs-all:
+	@echo "=== All service logs (last 20 lines each) ==="
+	@for f in $(LOG_DIR)/*service*.log; do \
+		if [ -f "$$f" ]; then \
+			name=$$(basename "$$f" .log); \
+			echo ""; \
+			echo "─── $$name ───"; \
+			tail -20 "$$f"; \
+		fi; \
+	done
+	@echo ""; \
+	echo "=== Monolith log (last 5 lines) ==="; \
+	tail -5 $(LOG_FILE) 2>/dev/null || echo "(no monolith log)"
+
+logs-all-follow:
+	@echo "Following all service logs (Ctrl+C to stop)..."
+	@for f in $(LOG_DIR)/*service*.log; do \
+		if [ -f "$$f" ]; then \
+			basename "$$f" .log; \
+		fi; \
+	done | xargs tail -F 2>/dev/null || echo "No service logs found."
+
+logs-svc:
+	@test -n "$(SVC_LOG)" || { echo "Usage: make logs-svc SVC_LOG=data-gateway"; exit 1; }
+	@tail -50 $(LOG_DIR)/$(SVC_LOG).log 2>/dev/null || echo "No log found for $(SVC_LOG)."
+
+logs-svc-follow:
+	@test -n "$(SVC_LOG)" || { echo "Usage: make logs-svc-follow SVC_LOG=notification-service"; exit 1; }
+	@tail -f $(LOG_DIR)/$(SVC_LOG).log 2>/dev/null || echo "No log found for $(SVC_LOG)."
+
+logs-service:
+	@echo "Available service logs:"
+	@ls -lh $(LOG_DIR)/*service*.log $(LOG_DIR)/data-gateway.log 2>/dev/null || echo "(no service logs yet)"
+	@echo ""
+	@echo "  make logs-svc SVC_LOG=notification-service    View a specific service"
+	@echo "  make logs-all                                  View all services"
+	@echo "  make logs-all-follow                           Live-follow all services"
+	@echo "  make logs                                      Monolith log (legacy)"
+
 .PHONY: clean
 clean:
 	find . -type d -name __pycache__ -not -path "./.venv/*" | xargs rm -rf
@@ -316,6 +472,73 @@ server-pull:
 server-df:
 	ssh $(SERVER) "df -h"
 
+# ─── Server Redis ─────────────────────────────────────────────────────────────
+.PHONY: server-redis-status server-redis-start server-redis-stop server-redis-restart server-redis-config
+
+server-redis-status:
+	@echo "=== Server Redis Status ==="
+	ssh $(SERVER) "redis-cli ping 2>/dev/null || echo 'NOT RUNNING'"
+	ssh $(SERVER) "redis-cli INFO memory 2>/dev/null | grep used_memory_human"
+	ssh $(SERVER) "redis-cli CONFIG GET maxmemory maxmemory-policy save 2>/dev/null"
+
+server-redis-start:
+	ssh $(SERVER) "sudo systemctl start redis-server && redis-cli ping && echo 'Redis started'"
+
+server-redis-stop:
+	ssh $(SERVER) "sudo systemctl stop redis-server && echo 'Redis stopped'"
+
+server-redis-restart:
+	ssh $(SERVER) "sudo systemctl restart redis-server && redis-cli ping && echo 'Redis restarted'"
+
+server-redis-config:
+	ssh $(SERVER) "redis-cli CONFIG SET maxmemory 128mb \
+		&& redis-cli CONFIG SET maxmemory-policy allkeys-lru \
+		&& redis-cli CONFIG SET save '' \
+		&& redis-cli CONFIG GET maxmemory maxmemory-policy save"
+
+# ─── Server Notification Service ──────────────────────────────────────────────
+.PHONY: server-notification-status server-notification-start server-notification-stop server-notification-logs
+.PHONY: server-notify-test server-dead-letter server-svcs-status
+
+server-notification-status:
+	@echo "=== Server Notification Service ==="
+	ssh $(SERVER) "systemctl is-active stockanalysis-notification 2>/dev/null || echo 'not loaded'"
+	ssh $(SERVER) "journalctl -u stockanalysis-notification --no-pager -n 10 2>/dev/null || echo 'no journal'"
+	ssh $(SERVER) "redis-cli XLEN notification:jobs 2>/dev/null || echo '0'"
+	ssh $(SERVER) "redis-cli XREAD COUNT 10 STREAMS notification:dead 0 2>/dev/null || echo 'no dead letters'"
+
+server-notification-start:
+	ssh $(SERVER) "sudo systemctl start stockanalysis-notification \
+		&& echo 'Notification service started' \
+		|| echo 'FAILED — check: journalctl -u stockanalysis-notification'"
+
+server-notification-stop:
+	ssh $(SERVER) "sudo systemctl stop stockanalysis-notification && echo 'Notification service stopped'"
+
+server-notification-logs:
+	ssh $(SERVER) "journalctl -u stockanalysis-notification --no-pager -n 50"
+
+server-notify-test:
+	ssh $(SERVER) "redis-cli XADD notification:jobs '*' \
+		chat_type intraday \
+		message '<b>🧪 Server Test</b>\n\nFrom: $(shell whoami)@$(shell hostname)\nTime: $(shell date)' \
+		parse_mode HTML \
+		message_type test \
+		timestamp '$(shell date -u +%Y-%m-%dT%H:%M:%S)'"
+	@echo "Test notification sent to server Redis."
+
+server-dead-letter:
+	ssh $(SERVER) "redis-cli XREAD COUNT 10 STREAMS notification:dead 0 2>/dev/null || echo 'No dead letters'"
+
+server-svcs-status:
+	@echo "=== StockAnalysis Services ==="
+	@for svc in redis-server stockanalysis stockanalysis-auth stockanalysis-notification; do \
+		printf "  %-40s " "$$svc"; \
+		ssh $(SERVER) "systemctl is-active $$svc 2>/dev/null || echo 'not loaded'"; \
+	done
+	@echo ""
+	ssh $(SERVER) "redis-cli INFO memory 2>/dev/null | grep used_memory_human" || true
+
 # Usage: make update-enctoken TOKEN=<your_enc_token>
 TOKEN ?=
 .PHONY: update-enctoken
@@ -336,3 +559,41 @@ auth-force:
 server-auth-force:
 	@echo "Force-refreshing enctoken on server (bypassing once-per-day guard)..."
 	ssh $(SERVER) "cd ~/StockAnalysis && .venv/bin/python auth/auth_login.py --force"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Notification Service
+# ──────────────────────────────────────────────────────────────────────────────
+.PHONY: run-notification
+
+run-notification:
+	@echo "Starting notification-service..."
+	@echo "Press Ctrl+C to stop."
+	REDIS_URL=redis://localhost:6379 PYTHONPATH=$(CURDIR) $(PYTHON) services/notification-service/main.py --consumer-name local-1
+
+.PHONY: svc-notification-logs svc-notification-check svc-notify-test svc-dead-letter
+
+svc-notification-logs:
+	@tail -50 logs/notification-service.log 2>/dev/null || echo "No notification service logs found."
+
+svc-notification-check:
+	@redis-cli XINFO GROUPS notification:jobs 2>/dev/null || echo "No consumer group yet (start notification service first)"
+	@redis-cli XLEN notification:jobs 2>/dev/null || echo "0"
+
+svc-notify-test:
+	@redis-cli XADD notification:jobs '*' \
+		chat_type intraday \
+		message "<b>🧪 Test Notification</b>\n\nMakefile test — redis://localhost:6379" \
+		parse_mode HTML \
+		message_type test \
+		symbol TEST \
+		timestamp "$$(date -u +%Y-%m-%dT%H:%M:%S)" 2>/dev/null || \
+	redis-cli XADD notification:jobs '*' \
+		chat_type intraday \
+		message "<b>Test Notification</b>" \
+		parse_mode HTML \
+		message_type test
+	@echo "Test notification sent to Redis stream."
+	@echo "Check with: make svc-notification-check"
+
+svc-dead-letter:
+	@redis-cli XREAD COUNT 10 STREAMS notification:dead 0 2>/dev/null || echo "No dead letters"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,38 @@ Mode selection in production (`PRODUCTION=1`) is time-based. In dev mode, `DEV_I
 ## Architecture
 
 ```
-intraday/intraday_monitor.py          ← Main entry point & orchestrator
+┌─────────────────────────────────────────────────────────────────┐
+│                    Microservices (Phase 1)                       │
+│                                                                  │
+│  ┌──────────┐        ┌──────────────────┐                       │
+│  │  Redis 7 │◄───────│  Monolith (until │                       │
+│  │ (message │   LB   │  fully extracted)│                       │
+│  │  broker) │        │ intraday_monitor │                       │
+│  └────┬─────┘        │  .py             │                       │
+│       │              └────────┬─────────┘                       │
+│       │  notification:jobs    │ send_notification()             │
+│       │  (stream)             │  ─→ Redis (primary)             │
+│       │                       │   → HTTP (fallback)             │
+│       ▼                       ▼                                 │
+│  ┌───────────────────────────────┐                              │
+│  │  notification-service         │  (EXTRACTED — Phase 1B)       │
+│  │  services/notification-       │                              │
+│  │  service/main.py              │                              │
+│  │    └── Consumes Redis stream  │                              │
+│  │    └── Telegram + Discord     │                              │
+│  │    └── Retry + dead letter    │                              │
+│  └───────────────────────────────┘                              │
+│                                                                  │
+│  Services to extract (planned):                                 │
+│    □ data-gateway     — yfinance + Sensibull + Zerodha WS       │
+│    □ analysis-engine  — 12 analysers + scoring                  │
+│    □ orchestrator     — cycle coordination                      │
+│    □ intelligence     — SignalBus + Correlator + LLM            │
+│    □ bot-service      — Telegram bot commands                   │
+└─────────────────────────────────────────────────────────────────┘
+
+Current monolith flow:
+intraday/intraday_monitor.py          ← Main entry point & orchestration
          |
          ├── create_stock_and_index_objects()   yfinance daily data download
          ├── update_zerodha_option_chain()       Kite instruments API → zerodha_ctx
@@ -178,6 +209,26 @@ When `ENABLE_NARRATOR=1` (requires `GEMINI_API_KEY`):
 | `OPTIONS_SOURCE` | `zerodha` | `zerodha` or `sensibull` for live option tick source |
 | `HEALTHCHECK_URL` | (empty) | Dead-man's switch ping URL (e.g., healthchecks.io) |
 
+### Redis (required for notification service)
+
+| Variable | Purpose |
+|----------|---------|
+| `REDIS_URL` | Redis connection string (default: `redis://localhost:6379`) |
+| `NOTIFICATION_CHANNEL` | `telegram`, `discord`, or `both` |
+
+### Per-Service Logging
+
+All services log to `logs/{service_name}.log` with 10 MB rotating files (3 backups). Per-service log level override:
+
+```bash
+LOG_LEVEL=INFO NOTIFICATION_LOG_LEVEL=DEBUG make run-dev
+```
+
+| Env Var | Effect |
+|----------|--------|
+| `LOG_LEVEL` | Global default for all services (default: `INFO`) |
+| `{SERVICE}_LOG_LEVEL` | Per-service override, e.g. `NOTIFICATION_LOG_LEVEL=DEBUG` |
+
 ---
 
 ## Automated Zerodha Authentication
@@ -249,8 +300,9 @@ make env-check                     # Verify required .env variables are set
 
 # Run
 make run-prod                      # PRODUCTION=1 intraday monitor
-make run-dev                       # DEV_INTRADAY=1 intraday monitor
-make run-dev-positional            # DEV_POSITIONAL=1 EOD analysis
+make run-dev                       # DEV_INTRADAY=1 + notification service (auto start/stop)
+make run-dev-positional            # DEV_POSITIONAL=1 EOD + notification service (auto start/stop)
+make run-dev-stop                  # Stop notification service (manual cleanup)
 make run-dev-stock-intraday STOCK=RELIANCE   # Single stock intraday
 make run-dev-stock-positional STOCK=RELIANCE # Single stock positional
 make run-dev-index-intraday INDEX=NIFTY      # Single index intraday
@@ -260,6 +312,19 @@ make run-postmarket                # Post-market analysis pipeline
 make deploy                        # git pull + restart service on EC2 via SSH
 make service-stop                  # Start EC2 (if stopped) + stop service; exits early on holidays
 make service-stop-force            # Same but bypasses holiday guard (dev use)
+
+# Redis
+make redis-install                 # Install Redis via Homebrew
+make redis-start                   # Start Redis service
+make redis-stop                    # Stop Redis service
+make redis-status                  # Check Redis status + memory
+make redis-config                  # Apply production config (128MB, no persistence)
+
+# Notification Service
+make run-notification              # Start notification service (foreground)
+make svc-notify-test               # Send test notification to Redis stream
+make svc-notification-check        # Check stream + consumer group
+make svc-dead-letter               # View failed notifications
 
 # Test
 make test                          # Full test suite
@@ -274,8 +339,13 @@ make typecheck                     # pyright type check
 
 # Maintenance
 make update-derivatives            # Refresh final_derivatives_list.json
-make logs                          # Tail last 50 lines of monitor.log
-make logs-follow                   # Follow logs/monitor.log live
+make logs                          # Monolith log (legacy)
+make logs-follow                   # Follow monolith log live
+make logs-all                      # View last 20 lines of every service log
+make logs-all-follow               # Follow all service logs live
+make logs-svc SVC_LOG=data-gateway # View one service log
+make logs-svc-follow SVC_LOG=...   # Follow one service log live
+make logs-service                  # List all available service logs
 make clean                         # Remove __pycache__, .pyc, pytest cache
 make clean-all                     # clean + remove .venv
 
@@ -287,6 +357,13 @@ make server-status                 # Show stock_analysis.service status
 make server-restart                # Restart stock_analysis.service
 make server-pull                   # git pull on server repo
 make server-df                     # Disk usage on server
+make server-redis-status           # Redis status + memory on server
+make server-redis-start            # Start Redis on server
+make server-redis-config           # Apply Redis config on server
+make server-notification-status    # Notification service status on server
+make server-notification-logs      # Notification service logs on server
+make server-notify-test            # Send test notification via server Redis
+make server-svcs-status            # All StockAnalysis service statuses
 make update-enctoken TOKEN=<tok>   # Update ZERODHA_ENC_TOKEN on server .env
 ```
 
@@ -300,7 +377,7 @@ StockAnalysis/
 ├── auth/              # auth_login.py — automated TOTP-based Zerodha enctoken refresh
 ├── backtest/          # Backtesting framework + Optuna optimizer
 ├── common/            # Stock.py, shared.py, constants.py, scoring.py, token_registry.py
-├── configs/           # custom_holidays.json, ml_config.yaml
+├── configs/           # custom_holidays.json, ml_config.yaml, redis.conf
 ├── data/              # final_derivatives_list.json, backtest results
 ├── docs/              # DESIGN.md, DATA_SCHEMA.md
 ├── fno/               # SensibullFetcher, sensibull_feed.py (OPTIONS_SOURCE=sensibull path)
@@ -309,14 +386,22 @@ StockAnalysis/
 ├── ml_pipeline/       # ML prediction pipeline (XGBoost, LightGBM, RF, Ensemble)
 ├── notification/      # Telegram sender + bot commands (Command Router pattern)
 ├── nse/               # NSE API wrappers + market calendar helpers
+├── plans/             # microservices_architecture.md — migration plan
 ├── post_market_analysis/  # FII/DII, sector perf, F&O OI, index returns pipeline
 ├── premarket/         # Global cues, bonds, commodities, pre-open report
 ├── scripts/           # deploy.py, service_stop.py (holiday-aware), system_config (systemd units)
 ├── sentiment/         # FinBERT news sentiment
+├── services/          # Microservices (Phase 1 — extracted services)
+│   ├── common/        # Shared infra: logging.py, redis_client.py, stock_proxy.py, health.py
+│   ├── notification-service/  # Notification stream consumer (EXTRACTED — Phase 1B)
+│   ├── data-gateway/  # yfinance + Sensibull + Zerodha WS (code ready, not deployed)
+│   ├── coordinator/   # Orchestrator + intelligence + bot (compact mode, designed)
+│   └── *-service/     # Future: orchestrator, analysis-engine, intelligence, bot, auth
 ├── tests/             # 951 tests across 41 files
 ├── zerodha/           # WebSocket lifecycle, TickStore, FuturesFetcher, LiveOptionsEngine
 ├── Makefile
-└── .env.template
+├── .env.template
+└── requirements.txt
 ```
 
 ### Key Files
@@ -334,8 +419,12 @@ StockAnalysis/
 | `analyser/Analyser.py` | BaseAnalyzer (decorator framework) + AnalyserOrchestrator |
 | `zerodha/futures_fetcher.py` | FuturesFetcher — Kite historical futures data |
 | `fno/sensibull_fetcher.py` | SensibullFetcher — Sensibull API (insights, OI chain, IV chart, OI history) |
-| `notification/Notification.py` | Telegram message sender (3 channels, retry logic) |
+| `notification/Notification.py` | Telegram message sender — routes through Redis by default, direct HTTP fallback |
 | `notification/bot_listener.py` | Telegram bot entry point (Command Router) |
+| `services/notification-service/main.py` | Notification stream consumer (EXTRACTED — Phase 1B) |
+| `services/common/logging.py` | Per-service logger factory (`get_logger("service-name")`) |
+| `services/common/stock_proxy.py` | Stock object ↔ Redis serialization |
+| `configs/redis.conf` | Redis configuration (128MB maxmemory, no persistence) |
 
 ---
 

--- a/common/constants.py
+++ b/common/constants.py
@@ -14,6 +14,8 @@ ENV_ENABLE_LIVE_OPTIONS = "ENABLE_LIVE_OPTIONS"   # Toggle real-time options ana
 ENV_LIVE_OPTIONS_ONLY   = "LIVE_OPTIONS_ONLY"     # Skip all regular analysis; run live options engine only
 ENV_ENABLE_INTELLIGENCE = "ENABLE_INTELLIGENCE"   # Toggle SignalBus + Correlator + morning bias
 ENV_ENABLE_NARRATOR     = "ENABLE_NARRATOR"       # Toggle LLM-powered trade narratives (requires GEMINI_API_KEY)
+# Notification is routed through Redis stream by default (notification/Notification.py).
+# Direct HTTP fallback when Redis is unavailable.
 ENV_OPTIONS_SOURCE      = "OPTIONS_SOURCE"         # "zerodha" (default) or "sensibull"
 
 # Indices for which live option chains are subscribed via WebSocket (both Zerodha and Sensibull).

--- a/configs/redis.conf
+++ b/configs/redis.conf
@@ -1,0 +1,41 @@
+# StockAnalysis Redis Configuration — Single Laptop, 8 GB RAM
+# This replaces the default redis.conf for the StockAnalysis deployment.
+# Copy to /etc/redis/redis.conf on the server and restart Redis.
+
+bind 127.0.0.1                    # localhost only in Phase 1
+# bind 127.0.0.1 <laptop-lan-ip>  # uncomment when adding a second machine
+# requirepass <a-strong-password> # uncomment when exposing to network
+port 6379
+
+# Memory
+maxmemory 128mb
+maxmemory-policy allkeys-lru
+
+# No disk persistence
+save ""
+appendonly no
+appendfsync no
+
+# Connection settings
+timeout 0
+tcp-keepalive 60
+tcp-backlog 511
+
+# Tuned for laptop
+hz 10
+lazyfree-lazy-eviction yes
+lazyfree-lazy-expire yes
+io-threads 1
+io-threads-do-reads no
+
+# Keyspace events
+notify-keyspace-events ""
+
+# Slow log
+slowlog-log-slower-than 10000
+slowlog-max-len 128
+
+# Safety
+stop-writes-on-bgsave-error no
+rdbchecksum no
+rdbcompression no

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,6 +1,6 @@
 # StockAnalysis - Comprehensive Design Document
 
-> **Last Updated**: May 2026 (OptionSellerCompositeAnalyser added: GAMMA_TRAP, RANGE_BOUND_SETUP, SKEW_FADE_SETUP with PRIORITY_OVERRIDE / winner-takes-all message dispatch; SENSEX added to live options indices; auth/auth_login.py for automated TOTP enctoken refresh; scripts/system_config systemd units; MIN_NOTIFICATION_SCORE_POSITIONAL=150; positional price-move filter 0.75%)
+> **Last Updated**: June 2026 (Phase 1B — notification-service extracted as first microservice; Redis stream dispatch replaces direct HTTP for all notifications; per-service logging via `services/common/logging.py`; Makefile updated with Redis and service management targets; `configs/redis.conf` for production Redis config)
 > **Purpose**: Complete architectural reference for the Indian Stock Market Analysis System targeting NSE (National Stock Exchange) equities. This document captures the entire codebase: architecture, data flows, module interactions, signal processing, scoring, notifications, and deployment details.
 
 ---
@@ -105,9 +105,31 @@ StockAnalysis/
 |   |-- constants.py                 # All weights, thresholds, env vars, categories
 |   |-- scoring.py                   # Score calculation, alignment bonus, should_notify()
 |   |-- helperFunctions.py           # Utilities (percentage change, JSON I/O, time checks)
-|   |-- logging_util.py              # Logger configuration
+|   |-- logging_util.py              # Logger configuration (monolith, legacy)
 |   |-- token_registry.py            # TokenRegistry — O(1) tick routing, zone management
-|
+
+|-- services/                        # Microservices (Phase 1 extraction)
+|   |-- common/
+|   |   |-- logging.py               # Per-service logger: get_logger("service-name")
+|   |   |-- redis_client.py          # Async Redis connection manager
+|   |   |-- redis_proxy.py           # Sync Redis wrapper (data-gateway)
+|   |   |-- serialization.py         # DataFrame/dict JSON serialization
+|   |   |-- health.py                # Service heartbeat loop
+|   |   |-- stream_consumer.py       # Base class for Redis Stream consumers
+|   |   |-- stock_proxy.py           # Stock object ↔ Redis serialization
+|   |-- notification-service/        # EXTRACTED — Phase 1B
+|   |   |-- main.py                  # Stream consumer: reads notification:jobs, sends Telegram/Discord
+|   |-- data-gateway/                # Code ready, not deployed
+|   |   |-- main.py                  # yfinance + Sensibull fetcher
+|   |   |-- yfinance_fetcher.py      # Async yfinance data fetcher
+|   |   |-- sensibull_fetcher.py     # Async Sensibull REST fetcher
+|   |-- coordinator/                 # Designed — orchestrator + intelligence + bot merged
+|   |-- orchestrator/                # Designed — standalone orchestrator
+|   |-- analysis-engine/             # Designed — stream consumer workers
+|   |-- intelligence-service/        # Designed — SignalBus + Correlator + Narrator
+|   |-- bot-service/                 # Designed — Telegram bot commands
+|   |-- auth-service/                # Designed — TOTP login command listener
+
 |-- notification/
 |   |-- Notification.py              # Telegram message sender
 |   |-- bot_listener.py              # Thin entry point: register_all() + LLM budget alert job
@@ -1661,16 +1683,19 @@ class NewsSentimentManager:
 ```python
 class TELEGRAM_NOTIFICATIONS:
     def send_notification(message, parse_mode="HTML"):
-        # Routes to correct channel based on shared.app_ctx.mode:
-        #   INTRADAY  -> INTRADAY_CHAT_ID
-        #   POSITIONAL -> POSITIONAL_CHAT_ID
-        # Only sends when is_production=True
-        # Retries up to 3 times with exponential backoff (2s, 4s) on HTTP error,
-        # Timeout, or ConnectionError. Timeout per attempt: 15s.
+        # ── Phase 1B: Redis primary path ───────────────────────────────
+        # 1. Try Redis: XADD notification:jobs {chat_type, message, parse_mode, ...}
+        #    → Consumed by notification-service (separate process)
+        # 2. Fallback: direct HTTP to Telegram/Discord if Redis unavailable
+        #
+        # Routes to correct channel based on chat_type:
+        #   "intraday"  -> INTRADAY_CHAT_ID
+        #   "positional" -> POSITIONAL_CHAT_ID
+        # Retries up to 3 times with exponential backoff on HTTP error.
 
     def send_live_options_notification(message, parse_mode="HTML"):
-        # Always routes to LIVE_OPTIONS_CHAT_ID (dedicated real-time channel)
-        # Bypasses mode check — live options alerts are mode-independent
+        # Same Redis primary path with chat_type="live_options"
+        # Direct HTTP fallback when Redis unavailable
 ```
 
 ### Telegram Channels

--- a/notification/Notification.py
+++ b/notification/Notification.py
@@ -1,9 +1,8 @@
-
-# Import the following modules
 import re
 import requests
 import json
 import os
+import datetime
 from common.constants import (
     TELEGRAM_INTRADAY_CHAT_ID,
     TELEGRAM_INTRADAY_TOKEN,
@@ -12,7 +11,6 @@ from common.constants import (
     TELEGRAM_LIVE_OPTIONS_TOKEN,
     TELEGRAM_LIVE_OPTIONS_CHAT_ID,
     TELEGRAM_URL,
-    ENV_PRODUCTION,
     NOTIFICATION_CHANNEL,
     DISCORD_INTRADAY_WEBHOOK_URL,
     DISCORD_POSITIONAL_WEBHOOK_URL,
@@ -22,21 +20,18 @@ from common.logging_util import logger
 
 
 def _html_to_discord(text: str) -> str:
-    """Convert Telegram HTML tags to Discord markdown."""
     text = re.sub(r"<b>(.*?)</b>", r"**\1**", text, flags=re.DOTALL)
     text = re.sub(r"<i>(.*?)</i>", r"*\1*", text, flags=re.DOTALL)
     text = re.sub(r"<code>(.*?)</code>", r"`\1`", text, flags=re.DOTALL)
     text = re.sub(r"<pre>(.*?)</pre>", r"```\1```", text, flags=re.DOTALL)
-    text = re.sub(r"<[^>]+>", "", text)  # strip remaining tags
+    text = re.sub(r"<[^>]+>", "", text)
     return text
 
 
 def _send_discord(webhook_url: str, message: str, parse_mode: str | None = None) -> bool:
-    """POST a message to a Discord webhook. Returns True on success."""
     if not webhook_url:
         return False
     content = _html_to_discord(message) if parse_mode and parse_mode.upper() == "HTML" else message
-    # Discord message limit is 2000 chars
     if len(content) > 2000:
         content = content[:1997] + "..."
     try:
@@ -52,117 +47,137 @@ def _send_discord(webhook_url: str, message: str, parse_mode: str | None = None)
     except Exception as e:
         logger.error(f"Discord webhook error: {e}")
         return False
- 
-# Function to send Push Notification
- 
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Redis dispatch — primary notification path.
+# All notifications are written to Redis stream "notification:jobs" and
+# the notification-service (separate process) reads and sends them.
+# Direct HTTP is the fallback when Redis is unavailable.
+# ═══════════════════════════════════════════════════════════════════════════
+
+_REDIS_CLIENT = None
+_REDIS_AVAILABLE = None  # None=not checked, True/False after first attempt
+
+def _get_redis():
+    global _REDIS_CLIENT, _REDIS_AVAILABLE
+    if _REDIS_AVAILABLE is False:
+        return None
+    if _REDIS_CLIENT is None:
+        redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+        try:
+            import redis as _sync_redis
+            _REDIS_CLIENT = _sync_redis.from_url(redis_url, decode_responses=True)
+            _REDIS_CLIENT.ping()
+            _REDIS_AVAILABLE = True
+            logger.info(f"[Notification] Redis dispatch active at {redis_url}")
+        except Exception as e:
+            logger.warning(f"[Notification] Redis unavailable: {e}. Using direct HTTP.")
+            _REDIS_AVAILABLE = False
+            return None
+    return _REDIS_CLIENT
+
+def _notify_via_redis(chat_type: str, message: str, parse_mode=None, message_type="general", symbol=None) -> bool:
+    rc = _get_redis()
+    if not rc:
+        return False
+    try:
+        rc.xadd("notification:jobs", {
+            "chat_type": chat_type,
+            "message": message,
+            "parse_mode": parse_mode or "",
+            "message_type": message_type,
+            "symbol": symbol or "",
+            "timestamp": str(datetime.datetime.now()),
+        }, maxlen=1000)
+        return True
+    except Exception as e:
+        logger.error(f"[Notification] Redis dispatch failed: {e}")
+        return False
+
+
 class TELEGRAM_NOTIFICATIONS:
     is_production = 0
     is_intraday = True
-    dev_notify = False   # Set to True (via DEV_NOTIFY=1) to send alerts in dev mode
-    @classmethod
-    def pushbullet_notif(cls,title, body):
-    
-        TOKEN = 'o.6J1qIOmIRX4MEtgqCho761YLe0VJcanD'  # Pass your Access Token here
-        # Make a dictionary that includes, title and body
-        msg = {"type": "note", "title": title, "body": body}
-        # Sent a posts request
-        resp = requests.post('https://api.pushbullet.com/v2/pushes',
-                            data=json.dumps(msg),
-                            headers={'Authorization': 'Bearer ' + TOKEN,
-                                    'Content-Type': 'application/json'})
-        if resp.status_code != 200:  # Check if fort message send with the help of status code
-            raise Exception('Error', resp.status_code)
-        else:
-            print('Message sent')
+    dev_notify = False
+
     @classmethod
     def send_notification(cls, message, parse_mode=None):
-        """Send a notification via Telegram, Discord, or both (controlled by NOTIFICATION_CHANNEL)."""
         if not cls.is_production and not cls.dev_notify:
             return
 
+        # Primary: Redis stream → notification-service
+        chat_type = "intraday" if cls.is_intraday else "positional"
+        if _notify_via_redis(chat_type, message, parse_mode, message_type="general"):
+            return
+
+        # Fallback: direct HTTP
         channel = NOTIFICATION_CHANNEL.lower()
 
         if channel in ("discord", "both"):
             webhook = (
                 DISCORD_INTRADAY_WEBHOOK_URL
-                if TELEGRAM_NOTIFICATIONS.is_intraday
+                if cls.is_intraday
                 else DISCORD_POSITIONAL_WEBHOOK_URL
             )
             _send_discord(webhook, message, parse_mode)
 
         if channel in ("telegram", "both"):
-            TELEGRAM_CHAT_ID = ""
-            TELEGRAM_TOKEN = ""
-            if TELEGRAM_NOTIFICATIONS.is_intraday:
-                TELEGRAM_CHAT_ID = TELEGRAM_INTRADAY_CHAT_ID
-                TELEGRAM_TOKEN = TELEGRAM_INTRADAY_TOKEN
-            else:
-                TELEGRAM_CHAT_ID = TELEGRAM_POSITIONAL_CHAT_ID
-                TELEGRAM_TOKEN = TELEGRAM_POSITIONAL_TOKEN
-
-            msg = {"chat_id": TELEGRAM_CHAT_ID, "text": message}
+            chat_id = TELEGRAM_INTRADAY_CHAT_ID if cls.is_intraday else TELEGRAM_POSITIONAL_CHAT_ID
+            token = TELEGRAM_INTRADAY_TOKEN if cls.is_intraday else TELEGRAM_POSITIONAL_TOKEN
+            payload = {"chat_id": chat_id, "text": message}
             if parse_mode:
-                msg["parse_mode"] = parse_mode
+                payload["parse_mode"] = parse_mode
             for attempt in range(1, 4):
                 try:
                     resp = requests.post(
-                        TELEGRAM_URL + TELEGRAM_TOKEN + "/sendMessage",
-                        json=msg,
+                        TELEGRAM_URL + token + "/sendMessage",
+                        json=payload,
                         timeout=15,
                     )
-                    if resp.status_code != 200:
-                        logger.error(f"Telegram send failed (attempt {attempt}) with status {resp.status_code}: {resp.text}")
-                        if attempt < 3:
-                            from time import sleep as _sleep
-                            _sleep(2 ** attempt)
-                        continue
-                    logger.info("Message sent successfully")
-                    logger.debug(f"Message: {message}")
-                    return True
-                except requests.Timeout:
-                    logger.error(f"Telegram send timeout (attempt {attempt})")
+                    if resp.status_code == 200:
+                        logger.info("Message sent directly (Redis fallback)")
+                        return True
+                    logger.error(f"Telegram send failed (attempt {attempt}): {resp.status_code}")
                     if attempt < 3:
                         from time import sleep as _sleep
                         _sleep(2 ** attempt)
-                except requests.ConnectionError:
-                    logger.error(f"Telegram connection error (attempt {attempt})")
+                except (requests.Timeout, requests.ConnectionError) as e:
+                    logger.error(f"Telegram {type(e).__name__} (attempt {attempt})")
                     if attempt < 3:
                         from time import sleep as _sleep
                         _sleep(2 ** attempt)
                 except Exception as e:
                     logger.error(f"Telegram send failed: {e}")
                     return False
-            return False  # all retry attempts exhausted
-
+            return False
         return True
 
     @classmethod
     def send_live_options_notification(cls, message, parse_mode="HTML"):
-        """Send a real-time options alert to the dedicated live options channel."""
         if not cls.is_production and not cls.dev_notify:
             return
 
-        channel = NOTIFICATION_CHANNEL.lower()
+        # Primary: Redis stream
+        if _notify_via_redis("live_options", message, parse_mode, message_type="live_options"):
+            return
 
+        # Fallback: direct HTTP
+        channel = NOTIFICATION_CHANNEL.lower()
         if channel in ("discord", "both"):
             _send_discord(DISCORD_LIVE_OPTIONS_WEBHOOK_URL, message, parse_mode)
-
         if channel in ("telegram", "both"):
             if not TELEGRAM_LIVE_OPTIONS_TOKEN or not TELEGRAM_LIVE_OPTIONS_CHAT_ID:
-                logger.debug("TELEGRAM_LIVE_OPTIONS_TOKEN/CHAT_ID not configured — skipping live options Telegram alert")
+                logger.debug("Live options Telegram not configured")
             else:
-                msg = {"chat_id": TELEGRAM_LIVE_OPTIONS_CHAT_ID, "text": message}
-                if parse_mode:
-                    msg["parse_mode"] = parse_mode
                 try:
                     resp = requests.post(
                         TELEGRAM_URL + TELEGRAM_LIVE_OPTIONS_TOKEN + "/sendMessage",
-                        json=msg,
+                        json={"chat_id": TELEGRAM_LIVE_OPTIONS_CHAT_ID, "text": message, "parse_mode": parse_mode},
                         timeout=10,
                     )
                     if resp.status_code != 200:
-                        logger.error(f"Live options Telegram send failed: {resp.status_code}: {resp.text}")
+                        logger.error(f"Live options send failed: {resp.status_code}: {resp.text}")
                 except Exception as e:
-                    logger.error(f"Live options Telegram send failed: {e}")
-
+                    logger.error(f"Live options send failed: {e}")
         return True

--- a/plans/microservices_architecture.md
+++ b/plans/microservices_architecture.md
@@ -1,0 +1,2229 @@
+# StockAnalysis — Distributed Microservices Architecture Design
+
+> **Last Updated**: June 2026
+> **Purpose**: Complete design for decomposing the monolithic StockAnalysis application into independently scalable services, solving the 12 PM thread-pool saturation stall and enabling horizontal scaling.
+> **Constraint**: Initial deployment on a **single spare laptop** (Intel i5-6200U, 2 physical cores / 4 threads, 8 GB RAM, Ubuntu 24.04). Must scale out to additional machines later **without code changes** — just by changing `REDIS_URL` and starting services on the new node.
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Design Principles](#2-design-principles)
+3. [Technology Stack](#3-technology-stack)
+4. [Service Topology](#4-service-topology)
+5. [Service Definitions](#5-service-definitions)
+6. [Communication Contracts](#6-communication-contracts)
+7. [Redis Data Schema](#7-redis-data-schema)
+8. [Data Flow Diagrams](#8-data-flow-diagrams)
+9. [Scaling Strategy](#9-scaling-strategy)
+10. [Deployment Strategy](#10-deployment-strategy)
+11. [Reliability & Fault Tolerance](#11-reliability--fault-tolerance)
+12. [Observability](#12-observability)
+13. [Migration Path](#13-migration-path)
+14. [Service Stub Specifications](#14-service-stub-specifications)
+
+---
+
+## 1. Problem Statement
+
+### Current Monolith Issues
+
+The current system runs as a single Python process (`intraday/intraday_monitor.py`) with all responsibilities interleaved:
+
+| Issue | Root Cause | Symptom |
+|-------|-----------|---------|
+| **12 PM stall** | 20-worker `ThreadPoolExecutor` saturated by blocking Sensibull HTTP calls | Process freezes, no analysis runs, ticks dropped |
+| **No independent scaling** | I/O-bound data fetching, CPU-bound analysis, and real-time tick processing share one process and one thread pool | Can't add more CPU for analysis without adding more I/O workers |
+| **Single point of failure** | Crash in any analyser kills WebSocket, data fetching, notifications, and the bot | Full system outage from one bug |
+| **Memory fragmentation** | `pd.concat()` churn, `oi_chain_history` list slicing, 500KB JSON payloads in gen-2 GC | Unpredictable 5-15s full GC pauses |
+| **Enctoken expiry disruption** | 403 re-auth runs subprocess, kills WebSocket, re-subscribes everything in the same process that's also doing analysis | Tick loss + analysis disruption simultaneously |
+| **Tight coupling** | `shared.app_ctx` global singleton holds Stock objects, WebSocket manager, SignalBus, Correlator, Narrator all in one namespace | Can't test or deploy any component in isolation |
+
+### Goals
+
+1. **Independent scaling**: Add more analysis workers without adding more data fetchers
+2. **Fault isolation**: A crash in the analysis engine doesn't kill the WebSocket feed
+3. **Resource separation**: I/O-bound, CPU-bound, and real-time work in separate processes
+4. **Zero-downtime deployment**: Update one service without restarting the whole system
+5. **Observable**: Per-service health, throughput, latency, and error rates
+6. **Backward compatible**: Existing Telegram bot commands, alert format, and analyser logic preserved
+
+---
+
+## 2. Design Principles
+
+| Principle | Application |
+|-----------|-------------|
+| **Service per resource type** | I/O services, CPU services, and real-time services are separate processes so OS scheduling isolates them |
+| **Redis as the backbone** | Single external dependency for pub/sub, streams, and shared state. Fits 4-core/8GB constraint (Redis uses ~50MB) |
+| **Idempotent consumers** | Stream consumers can re-process messages safely (analysis results overwrite, don't append) |
+| **Backpressure via streams** | Redis Streams with consumer groups + XCLAIM for stuck messages. No unbounded in-process queues |
+| **Shared schema, not shared code** | Each service has its own `pyproject.toml` but imports a shared `common/` package for data contracts |
+| **Health-first** | Every service exposes `/health` and writes heartbeat to Redis. Dead-man's switch per service |
+| **Config via env, not shared globals** | `shared.app_ctx` replaced by Redis-backed state. Services read their config from env vars only |
+
+---
+
+## 3. Technology Stack
+
+| Layer | Technology | Rationale |
+|-------|-----------|-----------|
+| **Message broker / shared state** | Redis 7.x (Streams + Pub/Sub + Hash/JSON) | Lightweight (~50MB RAM), single binary, fits 4-core server. Streams provide reliable delivery with consumer groups. No separate broker needed |
+| **Inter-service communication** | Redis Streams (reliable) + Redis Pub/Sub (fire-and-forget) | Streams for analysis jobs, results, notifications. Pub/Sub for real-time tick broadcast |
+| **Service framework** | Plain Python asyncio + `redis.asyncio` | No heavy framework (no Celery, no FastAPI for internal services). Keeps memory low. Each service is a `while True` loop reading from Redis |
+| **HTTP API (bot + health)** | `aiohttp` or `uvicorn + Starlette` (only for bot-service) | Only the bot-service needs HTTP (Telegram webhook). Other services are Redis-only |
+| **Process management** | `systemd` (Phase 1) → Docker Compose (Phase 2) → K8s (Phase 3) | systemd for 4-core server. Docker when adding a second node. K8s for multi-node |
+| **Service discovery** | Redis key `service:registry:{name}` with TTL heartbeat | No Consul/Eureka needed for 2-5 services |
+| **Monitoring** | Redis-backed health checks + structured JSON logs to stdout | systemd journal captures logs. No separate monitoring infra in Phase 1 |
+| **Language** | Python 3.13 (same as current) | No language change. Existing analysers ported as-is |
+
+### Why Redis Instead of RabbitMQ / Kafka
+
+| Factor | Redis | RabbitMQ | Kafka |
+|--------|-------|----------|-------|
+| RAM footprint | ~50MB | ~150MB | ~512MB+ |
+| Setup complexity | 1 binary | Erlang runtime | JVM + ZooKeeper |
+| Stream semantics | Consumer groups, XCLAIM, pending entries | Channels, prefetch | Partitions, consumer groups |
+| Shared state | Yes (Hash/JSON) | No | No |
+| Fit for 4-core/8GB | Excellent | OK | Too heavy |
+
+---
+
+## 4. Service Topology
+
+### Phase 1 — Single Laptop (i5-6200U, 2 cores/4 threads, 8 GB RAM)
+
+**The reality**: Your spare laptop is the only machine. All 7 services + Redis run on it. The design must be lean enough to not OOM-kill during peak market hours, but structured so that when you add a second machine, you just move services across — zero code changes.
+
+**Two deployment modes on the same laptop:**
+
+| Mode | When to use | Process count | RAM |
+|------|-------------|---------------|-----|
+| **Compact** (default) | Normal market days, single laptop | 5 processes | ~3.5 GB |
+| **Full** | When you need bot + intelligence on same machine | 8 processes | ~5 GB |
+
+#### Compact mode (recommended for single laptop)
+
+Consolidates the 3 lightest services into a single process with separate asyncio tasks. Same code, same Redis streams — just one process entry point that boots all three. This halves context-switch overhead on a 4-thread CPU.
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  LAPTOP (single node)                 │
+│                                                       │
+│  ┌──────────┐  ┌──────────────┐  ┌────────────────┐  │
+│  │  Redis 7 │  │ data-gateway │  │ analysis-engine│  │
+│  │ (~50 MB) │  │  (WS + HTTP) │  │   (1 worker)   │  │
+│  └────┬─────┘  └──────┬───────┘  └───────┬────────┘  │
+│       │               │                  │           │
+│       │    ┌──────────┴──────────────────┘           │
+│       │    │                                        │
+│       ▼    ▼                                        │
+│  ┌──────────────────────┐  ┌─────────────────────┐  │
+│  │  orchestrator +      │  │  notification +     │  │
+│  │  intelligence + bot  │  │  (merged process)   │  │
+│  │  (merged process)    │  │                     │  │
+│  └──────────────────────┘  └─────────────────────┘  │
+│                                                       │
+│  auth-service runs as systemd oneshot (cron-like)     │
+└─────────────────────────────────────────────────────┘
+```
+
+5 processes: Redis, data-gateway, analysis-engine, merged-coordinator (orchestrator+intelligence+bot), notification-service.
+
+#### Full mode (when adding features or debugging)
+
+All services as separate processes. Use this when debugging a specific service or when you have the second machine and can spread the load.
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  LAPTOP (single node)                 │
+│                                                       │
+│  Redis ─── data-gateway ─── orchestrator              │
+│              │                │                       │
+│              │          analysis-engine@1             │
+│              │                │                       │
+│              │     intelligence-service               │
+│              │                │                       │
+│              │     notification-service               │
+│              │                │                       │
+│              │          bot-service                   │
+│              │                                        │
+│         auth-service (oneshot/timer)                  │
+└─────────────────────────────────────────────────────┘
+```
+
+### Resource Allocation (Single Laptop — 8 GB RAM)
+
+| Service | Threads | RAM Budget | Process Count | Notes |
+|---------|---------|------------|---------------|-------|
+| Redis | 1 | 128 MB | 1 | `maxmemory 128mb`, LRU eviction |
+| data-gateway | 1+2 WS | 1.2 GB | 1 | Largest: holds TickStore, option chain, WS buffers |
+| analysis-engine | 1 | 600 MB | 1 worker | `MemoryMax=800M` in systemd |
+| merged-coordinator | 1 | 500 MB | 1 | orchestrator + intelligence + bot in one process |
+| notification-service | 1 | 200 MB | 1 | Lightweight: just reads streams, sends HTTP |
+| auth-service | — | 50 MB | 0 (oneshot) | Runs only at boot / on 403 |
+| **OS + overhead** | — | 2 GB | — | Ubuntu desktop + background |
+| **Total** | **~5** | **~4.7 GB** | **5** | **3.3 GB headroom for spikes** |
+
+> The i5-6200U has 4 hardware threads. With 5 processes doing mostly I/O (waiting on Redis/network), the OS scheduler handles this well. The CPU bottleneck is analysis-engine during the 5-min cycle burst — that's the only service that spikes to 100% on one core for ~2 seconds per stock.
+
+### Laptop-Specific Operational Concerns
+
+| Concern | Mitigation |
+|---------|-----------|
+| **Thermal throttling** | i5-6200U throttles at 80°C. analysis-engine bursts are short (2s/stock). Set `CPUQuota=75%` in systemd to leave thermal headroom. If laptop has no active cooling, reduce to 1 analysis worker |
+| **Lid close / suspend** | Disable suspend when on AC: `systemd-inhibit --what=handle-lid-switch` or set `HandleLidSwitch=ignore` in `/etc/systemd/logind.conf` |
+| **Not always-on** | Laptop may be powered off overnight. auth-service + orchestrator are triggered by systemd timers at 9:00 AM. If laptop is off at 9 AM, nothing runs — this is acceptable (same as current monolith behavior) |
+| **WiFi instability** | Use ethernet if possible. If WiFi drops, data-gateway auto-reconnects WS. Other services are unaffected (they talk to Redis on localhost) |
+| **Disk I/O** | Laptop HDD/SSD is fine — Redis is configured `save ""` (no disk persistence, all in-RAM). Logs go to systemd journal (ramfs) |
+| **Battery / power outage** | If laptop dies, all services die. systemd `Restart=always` brings them back when power returns. Redis loses in-memory state (acceptable — next cycle refetches everything) |
+
+### Phase 2 — Add a Second Machine (any old PC/laptop/mini-PC)
+
+**When you're ready**: Buy or repurpose any machine (even a Raspberry Pi 4 with 4GB RAM can run notification-service + bot-service). The transition is **zero code changes**:
+
+1. Install Redis client + Python on the new machine
+2. Clone the repo, set `REDIS_URL=redis://<laptop-ip>:6379` in `.env`
+3. Stop the service on the laptop: `systemctl stop stockanalysis-notification`
+4. Start it on the new machine: `systemctl start stockanalysis-notification`
+5. Done. The service now reads from Redis on the laptop over the network.
+
+```
+LAPTOP (Node 1 — data + Redis)          NEW MACHINE (Node 2 — compute + output)
+┌────────────────────────┐              ┌────────────────────────┐
+│ Redis                  │◄──── network ── REDIS_URL=laptop:6379  │
+│ data-gateway           │              │ analysis-engine ×2     │
+│ orchestrator           │              │ intelligence-service   │
+│ bot-service            │              │ notification-service   │
+│ auth-service (timer)   │              │                        │
+└────────────────────────┘              └────────────────────────┘
+```
+
+**Which services to move first** (in priority order):
+1. **analysis-engine** — CPU-heavy, benefits most from dedicated cores. Move to a machine with more cores.
+2. **notification-service** — Lightweight but I/O-bound. Can go anywhere.
+3. **intelligence-service** — LLM calls are I/O-bound. Can go anywhere.
+
+**Redis stays on the laptop** (Node 1) because it's close to data-gateway (the producer). Redis on localhost = <1ms latency for HGET/HSET. Moving Redis to Node 2 would add 1-5ms network latency to every tick publish.
+
+### Phase 3 — Three+ Machines (when you have a small cluster)
+
+```
+Node 1 (laptop)          Node 2 (old PC)         Node 3 (cloud VPS / mini-PC)
+┌──────────────┐        ┌──────────────┐        ┌──────────────────┐
+│ Redis        │        │ analysis ×3  │        │ analysis ×2      │
+│ data-gateway │        │ intelligence │        │ notification     │
+│ orchestrator │        │              │        │ bot-service      │
+│ auth-service │        │              │        │                  │
+└──────────────┘        └──────────────┘        └──────────────────┘
+```
+
+- Analysis workers can be spread across any number of machines — they all join the same Redis consumer group
+- A cloud VPS (e.g., AWS t3.micro free tier) can run notification + bot for 24/7 uptime even when laptop is off
+- Redis Sentinel or Redis Cluster can be added for HA if the laptop becomes unreliable
+
+### Phase 4 — Kubernetes (optional, only if cluster grows to 5+ nodes)
+
+- `analysis-engine` → `Deployment` with HPA (CPU > 70% → scale)
+- `data-gateway` → `StatefulSet` (1 replica, sticky WebSocket)
+- Redis → `StatefulSet` with persistence + Sentinel
+- All other services → `Deployment`s
+
+> **Kubernetes is overkill until you have 5+ machines.** systemd + Redis works perfectly for 1-3 nodes. Don't add complexity you don't need.
+
+---
+
+## 5. Service Definitions
+
+### 5.1 data-gateway
+
+**Responsibility**: All market data ingestion. Fetches from yfinance, Zerodha Kite REST + WebSocket, Sensibull REST + WebSocket. Publishes raw data to Redis.
+
+**Solves**: The 12 PM stall — data fetching is now isolated from analysis. If Sensibull API slows down, only this service is affected; analysis workers continue processing the last cycle's data.
+
+```
+Inputs:
+  - Redis: orchestrator:cycle_trigger stream (start new cycle)
+  - Env: ZerODHA credentials, Sensibull endpoints, yfinance config
+
+Outputs:
+  - Redis Pub/Sub channel "ticks:equity:{symbol}" — live equity ticks
+  - Redis Pub/Sub channel "ticks:index:{symbol}" — live index ticks
+  - Redis Pub/Sub channel "ticks:option:{symbol}" — live option ticks
+  - Redis Pub/Sub channel "ticks:future:{symbol}" — live futures ticks
+  - Redis Hash "data:price:{symbol}" — latest priceData DataFrame (serialized)
+  - Redis Hash "data:sensibull:{symbol}" — latest sensibull_ctx (JSON)
+  - Redis Hash "data:zerodha:{symbol}" — latest zerodha_ctx (JSON)
+  - Redis Hash "data:options_live:{symbol}" — live options tick data (JSON)
+  - Redis Hash "data:options_agg:{symbol}" — live options aggregate (JSON)
+  - Redis Hash "data:futures_live:{symbol}" — live futures tick data (JSON)
+  - Redis Stream "data:cycle_complete" — signal that all data for a cycle is fetched
+
+Key behaviours:
+  - Maintains Zerodha WebSocket connection independently
+  - Handles enctoken 403 re-auth internally (doesn't disrupt other services)
+  - Maintains Sensibull WebSocket connection independently
+  - On cycle trigger: fetches yfinance data for all symbols, Sensibull REST data
+  - Publishes each symbol's data as soon as fetched (streaming, not batch)
+  - Token registry management (option zone recentering) lives here
+  - TickStore lives here — publishes aggregate updates to Redis every 1s
+
+Process model:
+  - 1 main process (asyncio event loop)
+  - 2 background threads: Zerodha WS reactor, Sensibull WS reader
+  - HTTP fetches via aiohttp (async, non-blocking) — NO thread pool
+
+Restart policy:
+  - systemd Restart=always
+  - On restart: re-connects WebSocket, re-subscribes tokens, resumes fetching
+  - Other services continue using last-published data until new data arrives
+```
+
+### 5.2 orchestrator
+
+**Responsibility**: Cycle coordination, mode selection (intraday/positional/pre-market), scheduling.
+
+```
+Inputs:
+  - System clock (time-based mode selection)
+  - Env: PRODUCTION, DEV_INTRADAY, DEV_POSITIONAL, SHUTDOWN
+  - Redis: data:cycle_complete stream (data-gateway signals fetch done)
+
+Outputs:
+  - Redis Stream "orchestrator:cycle_trigger" — {cycle_id, mode, timestamp, symbols[]}
+  - Redis Stream "orchestrator:analysis_jobs" — one job per symbol per cycle
+  - Redis Hash "orchestrator:state" — current mode, cycle count, last cycle time
+
+Key behaviours:
+  - Every 310s (intraday) or once (positional): emits cycle_trigger
+  - On cycle_trigger: waits for data-gateway to publish cycle_complete
+  - Then emits one analysis_job per symbol to analysis_jobs stream
+  - Tracks cycle completion: waits for all analysis results before notifying
+  - Handles pre-market and post-market triggers
+  - Holiday gatekeeper: checks market calendar before triggering
+  - Healthcheck ping at end of each cycle
+
+Process model:
+  - 1 process, single-threaded asyncio loop
+  - No CPU-intensive work — pure coordination
+
+Restart policy:
+  - systemd Restart=always
+  - Stateless — reads cycle count from Redis on restart
+```
+
+### 5.3 analysis-engine
+
+**Responsibility**: Runs all 12+ analysers on a symbol's data. This is the CPU-intensive service that scales horizontally.
+
+```
+Inputs:
+  - Redis Stream "orchestrator:analysis_jobs" — {cycle_id, symbol, mode, data_ref}
+  - Redis Hash "data:price:{symbol}" — priceData
+  - Redis Hash "data:sensibull:{symbol}" — sensibull_ctx
+  - Redis Hash "data:zerodha:{symbol}" — zerodha_ctx
+  - Redis Hash "data:options_live:{symbol}" — live options (for live-mode analysers)
+  - Redis Hash "data:options_agg:{symbol}" — live options aggregate
+
+Outputs:
+  - Redis Stream "analysis:results" — {cycle_id, symbol, analysis_dict, score_result}
+  - Redis Hash "analysis:latest:{symbol}" — latest analysis result (for bot queries)
+
+Key behaviours:
+  - Consumer group "analysis-workers" on analysis_jobs stream
+  - Each worker picks one job, deserializes data, runs all analysers, publishes result
+  - Analysers are unchanged — same code, same decorators, same scoring
+  - Stock object is reconstructed from Redis hashes (lightweight, no WebSocket)
+  - After analysis: publishes result, ACKs the stream message
+  - On crash: unacked message is XCLAIMed by another worker after timeout
+  - gc.collect() after each symbol analysis (prevents gen-2 accumulation)
+
+Process model:
+  - N independent processes (systemd template unit: analysis-engine@.service)
+  - Each process is single-threaded (no GIL contention, no thread pool)
+  - Scale: start 1-2 on 4-core node, add more on second node
+
+Restart policy:
+  - systemd Restart=always (per-instance)
+  - Crashed worker's pending messages are reclaimed by live workers
+```
+
+### 5.4 intelligence-service
+
+**Responsibility**: SignalBus + SignalCorrelator + MarketNarrator (Gemini LLM). Cross-layer confluence detection and trade thesis generation.
+
+```
+Inputs:
+  - Redis Stream "analysis:results" — subscribes to all analysis results
+  - Redis Pub/Sub "ticks:option:{symbol}" — live option tick signals
+  - Redis Pub/Sub "ticks:equity:{symbol}" — live equity tick signals
+  - Redis Hash "data:*" — for context building (ContextBuilder reads from Redis)
+
+Outputs:
+  - Redis Stream "intelligence:narratives" — LLM-generated trade theses
+  - Redis Stream "intelligence:confluences" — detected confluence events
+  - Redis Pub/Sub "intelligence:signal" — real-time signal broadcast
+
+Key behaviours:
+  - SignalBus replaced by Redis Streams: all signals published to "intelligence:signals"
+  - SignalCorrelator subscribes to signal stream, detects confluence
+  - On HIGH confluence: calls Narrator (Gemini) asynchronously
+  - ContextBuilder reads from Redis hashes (replaces shared.app_ctx reads)
+  - Per-symbol cooldown (30 min) for narratives
+  - LLM budget tracking in Redis (daily token count, resets at midnight)
+  - EOD positional briefing after positional analysis completes
+
+Process model:
+  - 1 process, asyncio event loop
+  - LLM calls via aiohttp (non-blocking)
+  - Narrator runs in asyncio task (non-blocking)
+
+Restart policy:
+  - systemd Restart=always
+  - Signal buffer is in Redis (sorted set with timestamps) — survives restart
+```
+
+### 5.5 notification-service
+
+**Responsibility**: Consumes analysis results, confluences, narratives, and sends Telegram/Discord alerts. Handles retry, rate limiting, formatting.
+
+```
+Inputs:
+  - Redis Stream "analysis:results" — for score-gated notifications
+  - Redis Stream "intelligence:narratives" — for LLM trade theses
+  - Redis Stream "intelligence:confluences" — for confluence alerts
+  - Redis Stream "premarket:reports" — pre-market report messages
+  - Redis Stream "postmarket:reports" — post-market report messages
+
+Outputs:
+  - Telegram API (3 channels: intraday, positional, live-options)
+  - Discord webhooks (3 channels)
+  - Redis Stream "notification:log" — audit trail of sent messages
+
+Key behaviours:
+  - Consumer group "notifier" on each input stream
+  - Score gating: checks should_notify() before sending (same logic as monolith)
+  - Winner-takes-all: if PRIORITY_OVERRIDE set, sends only composite card
+  - Retry with exponential backoff (3 attempts, 2/4/8s)
+  - Rate limiting: max 20 messages/min per channel (Telegram limit)
+  - Message formatting: same MessageFormatter.py logic, serialized result → HTML
+  - Dead letter queue: failed notifications after 3 retries → "notification:dead"
+
+Process model:
+  - 1 process, asyncio event loop
+  - aiohttp for Telegram/Discord HTTP calls (non-blocking)
+
+Restart policy:
+  - systemd Restart=always
+  - Unacked messages reclaimed after 60s timeout
+```
+
+### 5.6 bot-service
+
+**Responsibility**: Telegram bot for interactive commands. Reads live state from Redis.
+
+```
+Inputs:
+  - Telegram Bot API (long polling or webhook)
+  - Redis Hash "data:*" — live market data for /ltp, /straddle, /walls
+  - Redis Hash "analysis:latest:{symbol}" — for analysis queries
+  - Redis Hash "orchestrator:state" — for /status
+  - Redis key "service:registry:*" — for /status health dashboard
+  - Redis key "llm:budget" — for /status LLM budget display
+
+Outputs:
+  - Telegram Bot API responses
+  - Redis command "data-gateway:enctoken_update" — for /enctoken command
+
+Key behaviours:
+  - All bot commands ported from notification/commands/
+  - find_stock_by_symbol() → Redis HSCAN across data:price:* keys
+  - /straddle, /walls → reads data:options_agg:{symbol} and data:options_live:{symbol}
+  - /status → reads service registry + feed health from Redis
+  - /enctoken → publishes to data-gateway:commands stream, data-gateway reconnects
+  - No analysis logic — pure read-only from Redis
+
+Process model:
+  - 1 process, python-telegram-bot (asyncio mode)
+  - JobQueue for scheduled LLM budget alerts
+
+Restart policy:
+  - systemd Restart=always
+  - Stateless — all state is in Redis
+```
+
+### 5.7 auth-service (optional, can be cron)
+
+**Responsibility**: Automated Zerodha TOTP login. Writes fresh enctoken to Redis + .env.
+
+```
+Inputs:
+  - Env: ZERODHA_USER, ZERODHA_PASS, ZERODHA_TOTP_SECRET
+  - Timer (cron / systemd timer)
+
+Outputs:
+  - Redis Hash "auth:zerodha" — {enctoken, issued_at, expires_at}
+  - Redis Pub/Sub "auth:enctoken_refreshed" — notifies data-gateway
+
+Key behaviours:
+  - Runs once at boot (systemd timer at 9:00 AM IST)
+  - Once-per-day guard (lock file, same as current)
+  - On 403 from data-gateway: data-gateway publishes to "auth:commands" stream
+    → auth-service runs fresh login → publishes new token
+  - data-gateway subscribes to "auth:enctoken_refreshed" and reconnects
+
+Process model:
+  - 1 process, runs on-demand (systemd oneshot) or as long-running listener
+  - Can be a cron job in Phase 1, promoted to a service in Phase 2
+
+Restart policy:
+  - systemd oneshot (Phase 1) / always (Phase 2)
+```
+
+---
+
+## 6. Communication Contracts
+
+### 6.1 Redis Streams (reliable, consumer groups)
+
+| Stream | Producer | Consumer(s) | Message Format |
+|--------|----------|-------------|----------------|
+| `orchestrator:cycle_trigger` | orchestrator | data-gateway | `{"cycle_id": "2026-06-26-32", "mode": "intraday", "timestamp": 1234567890, "symbols": ["NIFTY", "RELIANCE", ...]}` |
+| `orchestrator:analysis_jobs` | orchestrator | analysis-engine (consumer group) | `{"job_id": "uuid", "cycle_id": "2026-06-26-32", "symbol": "NIFTY", "mode": "intraday", "priority": "normal"}` |
+| `analysis:results` | analysis-engine | notification-service, intelligence-service | `{"job_id": "uuid", "cycle_id": "...", "symbol": "NIFTY", "analysis": {...}, "score_result": {...}, "timestamp": ...}` |
+| `intelligence:narratives` | intelligence-service | notification-service | `{"symbol": "NIFTY", "direction": "BULLISH", "level": "HIGH", "narrative": "...", "timestamp": ...}` |
+| `intelligence:confluences` | intelligence-service | notification-service, bot-service | `{"symbol": "NIFTY", "direction": "BULLISH", "level": "HIGH", "score": 18.5, "layers": ["live", "intraday"], "timestamp": ...}` |
+| `intelligence:signals` | all services | intelligence-service | `{"symbol": "NIFTY", "direction": "BULLISH", "source": "rsi_divergence", "layer": "intraday", "strength": "STRONG", "timestamp": ...}` |
+| `premarket:reports` | data-gateway | notification-service | `{"type": "global_cues", "message": "<html>...", "timestamp": ...}` |
+| `postmarket:reports` | analysis-engine | notification-service | `{"type": "fii_dii", "message": "<html>...", "timestamp": ...}` |
+| `notification:dead` | notification-service | (audit / manual retry) | `{"original_stream": "...", "message": "...", "error": "...", "attempts": 3, "timestamp": ...}` |
+| `data-gateway:commands` | bot-service | data-gateway | `{"command": "enctoken_update", "enctoken": "...", "timestamp": ...}` |
+| `auth:commands` | data-gateway | auth-service | `{"command": "refresh_enctoken", "reason": "403", "timestamp": ...}` |
+
+### 6.2 Redis Pub/Sub (fire-and-forget, low latency)
+
+| Channel | Producer | Subscriber(s) | Message Format |
+|---------|----------|---------------|----------------|
+| `ticks:equity:{symbol}` | data-gateway | intelligence-service | `{"token": 12345, "last_price": 2456.5, "ohlc": {...}, "volume": ..., "timestamp": ...}` |
+| `ticks:index:{symbol}` | data-gateway | intelligence-service | same as equity |
+| `ticks:option:{symbol}` | data-gateway | intelligence-service | `{"strike": 24500, "type": "CE", "ltp": 120.5, "oi": 1234567, "timestamp": ...}` |
+| `ticks:future:{symbol}` | data-gateway | (none currently, future use) | `{"expiry": "current", "ltp": ..., "oi": ..., "timestamp": ...}` |
+| `data:options_updated:{symbol}` | data-gateway | intelligence-service | `{"symbol": "NIFTY", "aggregate": {...}, "timestamp": ...}` (fired every 1s after aggregate recompute) |
+| `auth:enctoken_refreshed` | auth-service | data-gateway | `{"enctoken": "...", "issued_at": ...}` |
+
+### 6.3 Redis Hashes (shared state, latest-value-wins)
+
+| Key Pattern | Type | Owner | Contents |
+|-------------|------|-------|----------|
+| `data:price:{symbol}` | Hash | data-gateway | `{"priceData_json": "...", "ltp": 2456.5, "ltp_change_perc": 1.23, "prevDayOHLCV_json": "...", "daily_hv": 18.5}` |
+| `data:sensibull:{symbol}` | Hash | data-gateway | `{"current_json": "...", "historical_data_json": "...", "oi_chain_json": "...", "oi_chain_history_json": "...", "iv_chart_history_json": "...", "oi_history_json": "..."}` |
+| `data:zerodha:{symbol}` | Hash | data-gateway | `{"option_chain_current_json": "...", "futures_mdata_json": "...", "futures_data_current_json": "..."}` |
+| `data:options_live:{symbol}` | Hash | data-gateway | `{"{strike}_{CE|PE}": "{ltp, oi, volume, ...}", ...}` (one field per strike+type) |
+| `data:options_agg:{symbol}` | Hash | data-gateway | `{"live_pcr": 1.23, "atm_strike": 24500, "max_oi_ce_strike": 24700, "max_oi_pe_strike": 24300, "atm_straddle_premium": 185.5, ...}` |
+| `data:futures_live:{symbol}` | Hash | data-gateway | `{"current_ltp": ..., "current_oi": ..., "next_ltp": ..., "next_oi": ...}` |
+| `data:zerodha_tick:{symbol}` | Hash | data-gateway | `{"last_price": ..., "ohlc": ..., "volume": ..., "buy_qty": ..., "sell_qty": ..., "average_traded_price": ...}` |
+| `analysis:latest:{symbol}` | Hash | analysis-engine | `{"analysis_json": "...", "score_result_json": "...", "timestamp": ...}` |
+| `orchestrator:state` | Hash | orchestrator | `{"mode": "intraday", "cycle_count": 32, "last_cycle_time": ..., "last_cycle_id": "..."}` |
+| `service:registry:{name}` | Hash | each service | `{"name": "data-gateway", "pid": 12345, "status": "healthy", "last_heartbeat": ..., "version": "1.0.0", "stats_json": "..."}` (TTL 30s) |
+| `llm:budget` | Hash | intelligence-service | `{"daily_tokens": 35000, "daily_limit": 900000, "date": "2026-06-26", "budget_warned": "false"}` |
+| `auth:zerodha` | Hash | auth-service | `{"enctoken": "...", "issued_at": ..., "expires_at": ...}` |
+| `intelligence:signal_buffer:{symbol}` | ZSet | intelligence-service | `(timestamp, signal_json)` — time-windowed signal buffer for correlator (TTL 6h) |
+
+### 6.4 Serialization Strategy
+
+| Data Type | Serialization | Rationale |
+|-----------|---------------|-----------|
+| DataFrames (priceData, historical_data) | `pandas.to_json(orient="split")` | Compact, preserves dtypes, fast |
+| Nested dicts (sensibull_ctx, analysis) | `json.dumps()` with `default=str` | Standard, debuggable |
+| Live tick data (high frequency) | `orjson.dumps()` if available, else `json.dumps()` | Speed for pub/sub |
+| Large oi_chain_history | Store only latest 5 in Redis, keep 15 in data-gateway memory | Reduces Redis memory |
+
+---
+
+## 7. Redis Data Schema
+
+### 7.1 Memory Estimation (50 stocks + 4 indices)
+
+| Key Pattern | Count | Size per key | Total |
+|-------------|-------|-------------|-------|
+| `data:price:*` | 54 | ~50 KB (5d × 5m DataFrame JSON) | ~2.7 MB |
+| `data:sensibull:*` | 54 | ~200 KB (oi_chain + insights + history) | ~10.8 MB |
+| `data:zerodha:*` | 54 | ~30 KB (option chain metadata) | ~1.6 MB |
+| `data:options_live:*` | 4 (indices only) | ~50 KB (200 strikes × CE/PE) | ~200 KB |
+| `data:options_agg:*` | 4 | ~2 KB | ~8 KB |
+| `data:zerodha_tick:*` | 54 | ~1 KB | ~54 KB |
+| `analysis:latest:*` | 54 | ~5 KB | ~270 KB |
+| Streams (retained 1h) | 8 streams | ~500 KB each (600 msg/hr × ~1KB) | ~4 MB |
+| Service registry | 5 (compact mode) | ~1 KB | ~5 KB |
+| **Total** | | | **~20 MB** |
+
+> Redis maxmemory configured at **128 MB** for the laptop. 20 MB usage leaves ~108 MB headroom for stream growth. If Redis hits 128 MB, LRU eviction automatically removes oldest stream entries — analysis continues with slightly shorter history.
+
+### 7.2 Stream Retention Policy
+
+```redis
+# Each stream trimmed to last 1 hour of messages
+XADD analysis:results MAXLEN ~ 360 * 60  # ~360 results per hour (50 stocks / 5 min)
+XADD orchestrator:analysis_jobs MAXLEN ~ 360
+XADD intelligence:signals MAXLEN ~ 2000  # ~2000 signals per hour
+XADD intelligence:narratives MAXLEN ~ 30  # ~30 narratives per hour (cooldown-limited)
+```
+
+### 7.3 Consumer Group Setup
+
+```redis
+# analysis-engine workers
+XGROUP CREATE orchestrator:analysis_jobs analysis-workers $ MKSTREAM
+
+# notification-service
+XGROUP CREATE analysis:results notifier $ MKSTREAM
+XGROUP CREATE intelligence:narratives notifier $ MKSTREAM
+XGROUP CREATE intelligence:confluences notifier $ MKSTREAM
+
+# intelligence-service
+XGROUP CREATE analysis:results intelligence $ MKSTREAM
+XGROUP CREATE intelligence:signals intelligence $ MKSTREAM
+```
+
+---
+
+## 8. Data Flow Diagrams
+
+### 8.1 Intraday Cycle (5-min loop)
+
+```
+orchestrator                    data-gateway                    analysis-engine
+     │                               │                               │
+     │ 1. XADD cycle_trigger         │                               │
+     │──────────────────────────────>│                               │
+     │                               │                               │
+     │                               │ 2. Fetch yfinance (async)     │
+     │                               │    Fetch Sensibull REST       │
+     │                               │    HSET data:price:*          │
+     │                               │    HSET data:sensibull:*      │
+     │                               │                               │
+     │                               │ 3. XADD cycle_complete        │
+     │<──────────────────────────────│                               │
+     │                               │                               │
+     │ 4. XADD analysis_jobs         │                               │
+     │    (one per symbol)           │                               │
+     │──────────────────────────────────────────────────────────────>│
+     │                               │                               │
+     │                               │                  5. XREADGROUP │
+     │                               │                               │
+     │                               │  6. HGET data:price:{symbol}  │
+     │                               │<──────────────────────────────│
+     │                               │  7. HGET data:sensibull:*     │
+     │                               │<──────────────────────────────│
+     │                               │                               │
+     │                               │          8. Run 12 analysers  │
+     │                               │             + scoring         │
+     │                               │                               │
+     │                               │          9. XADD results      │
+     │                               │──────────────────────────────>│ (to notification + intelligence)
+     │                               │                               │
+     │                               │          10. XACK job         │
+     │                               │                               │
+     │ 11. Monitor results stream    │                               │
+     │     (wait for all symbols)    │                               │
+     │                               │                               │
+     │ 12. Ping healthcheck          │                               │
+     │     Sleep 310s                │                               │
+```
+
+### 8.2 Live Options Tick (real-time, ~1s)
+
+```
+Zerodha WebSocket
+       │
+       ▼
+data-gateway
+       │
+       ├── TickStore.update_option_tick()  (in-memory, same as now)
+       ├── TickStore.recompute_options_aggregate()  (throttled 1s)
+       │
+       ├── PUBLISH ticks:option:{symbol}  (raw tick, for intelligence)
+       ├── HSET data:options_live:{symbol}  (per-strike data)
+       ├── HSET data:options_agg:{symbol}  (aggregate: PCR, max pain, walls)
+       └── PUBLISH data:options_updated:{symbol}  (aggregate update notification)
+                │
+                ▼
+       intelligence-service
+                │
+                ├── SignalBus.emit() → XADD intelligence:signals
+                ├── LiveOIAnalyser checks (PCR crossover, wall breach)
+                ├── LiveStraddleAnalyser checks (IV change, skew)
+                ├── SignalCorrelator.on_signal() → check confluence
+                │
+                ├── If confluence detected:
+                │   ├── XADD intelligence:confluences
+                │   └── Narrator.narrate_async() → Gemini LLM
+                │       └── XADD intelligence:narratives
+                │
+                ▼
+       notification-service
+                │
+                ├── XREADGROUP confluences → send Telegram alert
+                └── XREADGROUP narratives → send LLM thesis to live-options channel
+```
+
+### 8.3 Enctoken Expiry Recovery (403 at noon)
+
+```
+Zerodha WebSocket (403 error)
+       │
+       ▼
+data-gateway
+       │
+       ├── Log 403, mark WS disconnected
+       ├── HSET service:registry:data-gateway status=degraded
+       ├── XADD auth:commands {command: refresh_enctoken, reason: 403}
+       │        │
+       │        ▼
+       │   auth-service
+       │        │
+       │        ├── Run TOTP login flow
+       │        ├── HSET auth:zerodha {enctoken, issued_at}
+       │        └── PUBLISH auth:enctoken_refreshed
+       │                 │
+       │                 ▼
+       │   data-gateway (subscribed)
+       │        │
+       │        ├── Update enctoken
+       │        ├── Reconnect WebSocket
+       │        ├── Re-subscribe all tokens
+       │        ├── HSET service:registry:data-gateway status=healthy
+       │        └── Resume tick publishing
+       │
+       └── (Other services continue using last-published data.
+            No stall. No disruption to analysis or notifications.)
+```
+
+### 8.4 Bot Command (/straddle NIFTY)
+
+```
+User sends /straddle NIFTY to Telegram
+       │
+       ▼
+bot-service
+       │
+       ├── Parse command
+       ├── HGET data:options_agg:NIFTY  → PCR, ATM, straddle premium
+       ├── HGET data:options_live:NIFTY  → CE/PE leg LTPs
+       ├── HGET data:zerodha_tick:NIFTY  → spot price
+       ├── Format response (same as current cmd_straddle)
+       └── Send via Telegram Bot API
+```
+
+---
+
+## 9. Scaling Strategy
+
+### 9.1 Which Services Scale Horizontally
+
+| Service | Scales? | Mechanism | Limit |
+|---------|---------|-----------|-------|
+| data-gateway | **No** (singleton) | 1 instance — WebSocket is stateful | N/A |
+| orchestrator | **No** (singleton) | 1 instance — cycle coordination | N/A |
+| analysis-engine | **Yes** | Add more consumer processes (same or new machine) | Redis throughput (~100K ops/s) |
+| intelligence-service | **Limited** | 1-2 instances (correlator state in Redis) | LLM API rate (15 RPM) |
+| notification-service | **Yes** | Add more consumer processes | Telegram rate (30 msg/min) |
+| bot-service | **No** (singleton) | 1 instance — Telegram long-polling | N/A |
+| auth-service | **No** (singleton) | 1 instance | N/A |
+
+### 9.2 Gradual Scaling Path (from 1 laptop to N machines)
+
+The design is future-proof: **scaling = starting more processes**, whether on the same machine or a new one. The code never changes — only `REDIS_URL` and `systemctl start`.
+
+```
+Step 0: Single laptop (compact mode)
+  └─ 1 analysis worker, ~4.7 GB RAM used
+
+Step 1: Single laptop (full mode) — if you have RAM headroom
+  └─ 1 analysis worker, all services separate, ~5 GB RAM
+
+Step 2: Single laptop + a second worker
+  └─ systemctl start stockanalysis-analysis@2
+  └─ 2 workers, ~5.3 GB RAM. Only do this if laptop has thermal headroom.
+
+Step 3: Add a second machine (any old PC/laptop/RPi)
+  └─ Move analysis-engine to new machine:
+     - laptop: systemctl stop stockanalysis-analysis@1
+     - new machine: REDIS_URL=redis://laptop:6379 systemctl start stockanalysis-analysis@1
+  └─ Zero code changes. Analysis jobs flow through Redis over network.
+
+Step 4: Move more services to the second machine
+  └─ Move notification-service, intelligence-service to new machine
+  └─ Laptop now only runs: Redis + data-gateway + orchestrator + bot + auth
+  └─ Laptop RAM drops to ~2 GB, freeing resources for data-gateway
+
+Step 5: Add a third machine (cloud VPS for 24/7 uptime)
+  └─ Move bot-service + notification-service to VPS
+  └─ VPS stays online even when laptop is powered off
+  └─ Laptop only runs during market hours (9 AM - 8 PM IST)
+
+Step 6: Kubernetes (only if 5+ machines)
+  └─ Convert systemd units to K8s manifests
+  └─ HPA for analysis-engine (auto-scale on CPU)
+```
+
+### 9.3 analysis-engine Scaling (same machine or across machines)
+
+```bash
+# Single laptop: 1 worker (default, safe for thermal)
+sudo systemctl start stockanalysis-analysis@1
+
+# Single laptop: 2 workers (if thermal allows — watch `sensors` output)
+sudo systemctl start stockanalysis-analysis@2
+
+# New machine: point at laptop's Redis, start workers
+REDIS_URL=redis://laptop-ip:6379 sudo systemctl start stockanalysis-analysis@1
+REDIS_URL=redis://laptop-ip:6379 sudo systemctl start stockanalysis-analysis@2
+REDIS_URL=redis://laptop-ip:6379 sudo systemctl start stockanalysis-analysis@3
+```
+
+Each worker joins the same consumer group `analysis-workers`. Redis distributes jobs round-robin. If a worker crashes, its pending jobs are XCLAIMed by a live worker after 120s. Workers on different machines work identically — they just read from a remote Redis instead of localhost.
+
+### 9.4 Load-Based Auto-Scaling (future, when multi-node)
+
+```python
+# Simple scaler script (can run on any machine, or as a cron job)
+# Checks Redis stream lag and starts/stops workers via SSH
+
+import subprocess
+
+PENDING_THRESHOLD = 20  # jobs waiting > 1 cycle = scale up
+IDLE_THRESHOLD = 5      # pending < 5 for 3 cycles = scale down
+
+# XPENDING orchestrator:analysis_jobs analysis-workers
+# If pending > 20: SSH to spare machine, start another worker
+# If pending < 5 for 3 cycles: SSH to spare machine, stop a worker
+```
+
+### 9.5 Throughput Targets
+
+| Metric | Monolith (now) | 1 Laptop (compact) | 1 Laptop + 2nd machine | 3 machines |
+|--------|---------------|--------------------|-----------------------|------------|
+| Analysis cycle time (50 stocks) | 60-90s (stalls at noon) | 40-55s (1 worker, no stall) | 20-30s (3 workers) | 10-15s (5 workers) |
+| Max stocks per cycle | ~60 (thread pool) | ~150 (Redis throughput) | ~300 | ~500+ |
+| WebSocket tick latency | 50-200ms (shared CPU) | 10-50ms (dedicated) | 10-50ms | 10-50ms |
+| Enctoken recovery | 60-120s (disrupts all) | 15-30s (isolated) | 15-30s | 15-30s |
+| RAM used (laptop) | ~3 GB (monolith) | ~4.7 GB (5 processes) | ~2 GB (3 services left) | ~2 GB |
+| 12 PM stall | **Yes** | **No** (data-gateway isolates I/O) | **No** | **No** |
+
+---
+
+## 10. Deployment Strategy
+
+### 10.1 Phase 1 — systemd on Laptop (single machine)
+
+**Compact mode (default — 5 processes):**
+
+```
+/etc/systemd/system/
+├── stockanalysis-redis.service              # Redis server (maxmemory 128mb)
+├── stockanalysis-data-gateway.service       # Data ingestion (WS + HTTP)
+├── stockanalysis-analysis@.service          # Analysis workers (template, start @1)
+├── stockanalysis-coordinator.service        # Merged: orchestrator + intelligence + bot
+├── stockanalysis-notification.service       # Telegram/Discord sender
+├── stockanalysis-auth.service               # Zerodha TOTP login (oneshot)
+├── stockanalysis-auth.timer                 # Mon-Fri 09:00 IST
+├── stockanalysis.timer                      # Mon-Fri 09:00 IST (starts coordinator)
+├── stockanalysis-positional.timer           # Mon-Fri 20:00 IST
+```
+
+**Full mode (when ready — 8 processes):**
+
+```
+/etc/systemd/system/
+├── stockanalysis-redis.service
+├── stockanalysis-data-gateway.service
+├── stockanalysis-orchestrator.service       # Separate orchestrator
+├── stockanalysis-analysis@.service          # Workers
+├── stockanalysis-intelligence.service       # Separate intelligence
+├── stockanalysis-notification.service
+├── stockanalysis-bot.service                # Separate bot
+├── stockanalysis-auth.service + .timer
+├── stockanalysis.timer + positional.timer
+```
+
+Switch between compact and full by enabling/disabling the merged vs separate units. The code is the same — `coordinator.service` just imports and runs all three entry points in one asyncio loop.
+
+**Service dependency graph (compact mode):**
+```
+redis.service
+    ├── data-gateway.service       (Requires=redis)
+    ├── coordinator.service        (Requires=redis, data-gateway)
+    ├── analysis@%.service         (Requires=redis)
+    └── notification.service       (Requires=redis)
+```
+
+**Laptop-specific systemd hardening:**
+```ini
+# In each service unit file:
+
+# Thermal protection — don't let any service pin the CPU at 100%
+CPUQuota=80%
+CPUWeight=50
+
+# Memory protection — OOM-kill this service, not the whole laptop
+MemoryMax=1200M           # adjust per service
+MemorySwapMax=512M        # allow limited swap usage
+
+# Don't restart too aggressively on a laptop (prevents thermal spiral)
+Restart=always
+RestartSec=10             # 10s between restarts (was 5s for server)
+StartLimitBurst=5
+StartLimitIntervalSec=300 # max 5 restarts per 5 min, then stop
+
+# Priority: data-gateway is most important, give it higher CPU priority
+# (set CPUWeight=100 in data-gateway, 50 in others)
+```
+
+**Preventing laptop suspend during market hours:**
+```ini
+# /etc/systemd/system/stockanalysis-data-gateway.service
+[Unit]
+# Block system suspend while this service is active
+Conflicts=suspend.target hibernate.target hybrid-sleep.target
+```
+
+Or globally:
+```bash
+# /etc/systemd/logind.conf
+HandleLidSwitch=ignore        # don't suspend on lid close
+HandleLidSwitchExternalPower=ignore
+HandleLidSwitchDocked=ignore
+```
+
+### 10.2 Phase 2 — Add a Second Machine (zero code changes)
+
+**On the laptop (Node 1):**
+```bash
+# Allow Redis to accept connections from the new machine
+# /etc/redis/redis.conf
+bind 127.0.0.1 <laptop-lan-ip>
+requirepass <a-strong-password>    # IMPORTANT: set a password if exposing Redis
+
+# Restart Redis
+sudo systemctl restart stockanalysis-redis
+
+# Stop the services you're moving to Node 2
+sudo systemctl stop stockanalysis-analysis@1
+sudo systemctl stop stockanalysis-notification
+```
+
+**On the new machine (Node 2):**
+```bash
+# Install Python + Redis client + clone repo
+git clone <repo> ~/StockAnalysis
+cd ~/StockAnalysis
+make venv && make install
+
+# Configure .env
+REDIS_URL=redis://:<password>@<laptop-lan-ip>:6379
+# ... other env vars (Telegram tokens, etc.)
+
+# Install systemd units (same files as laptop)
+sudo cp scripts/system_config/stockanalysis-analysis@.service /etc/systemd/system/
+sudo cp scripts/system_config/stockanalysis-notification.service /etc/systemd/system/
+
+# Start the services — they connect to Redis on the laptop
+sudo systemctl start stockanalysis-analysis@1
+sudo systemctl start stockanalysis-analysis@2
+sudo systemctl start stockanalysis-notification
+```
+
+**Verify:**
+```bash
+# On Node 2: check it's connected to Redis
+redis-cli -u "redis://:<password>@<laptop-lan-ip>:6379" PING
+# → PONG
+
+# Check the worker joined the consumer group
+redis-cli -u "..." XINFO GROUPS orchestrator:analysis_jobs
+# → Should show analysis-workers group with 2 consumers
+
+# Check Node 2 worker is processing jobs
+redis-cli -u "..." XINFO CONSUMERS orchestrator:analysis_jobs analysis-workers
+# → Should show worker-1 and worker-2 with pending count
+```
+
+### 10.3 Phase 3 — Docker Compose (when you have 2+ machines and want containerization)
+
+Only adopt Docker when you have a second machine and want reproducible deploys. On a single laptop, systemd is lighter (no Docker daemon, no container runtime overhead).
+
+```yaml
+# docker-compose.yml (Node 1: laptop — data + coordination + Redis)
+services:
+  redis:
+    image: redis:7-alpine
+    ports: ["6379:6379"]
+    command: redis-server --maxmemory 128mb --maxmemory-policy allkeys-lru --save ""
+    volumes: ["redis-data:/data"]
+    restart: always
+
+  data-gateway:
+    build: ./services/data-gateway
+    env_file: .env
+    depends_on: [redis]
+    restart: always
+    deploy:
+      resources:
+        limits: { memory: 1.2G }
+
+  coordinator:
+    build: ./services/coordinator
+    env_file: .env
+    depends_on: [redis, data-gateway]
+    restart: always
+    deploy:
+      resources:
+        limits: { memory: 500M }
+
+volumes:
+  redis-data:
+```
+
+```yaml
+# docker-compose.yml (Node 2: compute node)
+services:
+  analysis-engine:
+    build: ./services/analysis-engine
+    env_file: .env
+    environment:
+      - REDIS_URL=redis://:<password>@<laptop-ip>:6379
+    deploy:
+      replicas: 3
+      resources:
+        limits: { memory: 800M }
+    restart: always
+
+  notification-service:
+    build: ./services/notification-service
+    env_file: .env
+    environment:
+      - REDIS_URL=redis://:<password>@<laptop-ip>:6379
+    restart: always
+```
+
+### 10.4 Phase 4 — Kubernetes (only when 5+ nodes)
+
+Only when the cluster grows beyond what Docker Compose can manage. systemd + Docker Compose covers 1-4 machines perfectly.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: analysis-engine
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: analysis-engine
+        image: stockanalysis/analysis-engine:latest
+        env:
+        - name: REDIS_URL
+          value: "redis://redis-service:6379"
+        resources:
+          requests: { cpu: "500m", memory: "512Mi" }
+          limits: { cpu: "1000m", memory: "800Mi" }
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: analysis-engine-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: analysis-engine
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+```
+
+> **Don't jump to K8s prematurely.** The same Python code runs under systemd, Docker Compose, and K8s. Start with systemd, add Docker when you get a second machine, add K8s only when you have 5+ machines and need auto-scaling/orchestration.
+
+---
+
+## 11. Reliability & Fault Tolerance
+
+### 11.1 Failure Modes & Mitigations
+
+| Failure | Monolith Behavior | Microservices Behavior |
+|---------|-------------------|----------------------|
+| Sensibull API timeout | Thread pool stalls, all analysis stops | data-gateway retries, analysis-engine uses last cached data from Redis |
+| Analysis worker crash | Entire process dies, all ticks lost | Worker's pending job XCLAIMed by another worker in 120s |
+| Enctoken expiry (403) | Subprocess + WS reconnect in same process, 60-120s disruption | auth-service refreshes token, data-gateway reconnects in 15-30s, other services unaffected |
+| Redis crash | N/A (no Redis in monolith) | All services degrade gracefully — data-gateway buffers in-memory, orchestrator pauses cycles, bot-service shows "degraded" |
+| Telegram API down | Retry in same thread, blocks analysis | notification-service retries independently, analysis continues, messages queued in Redis stream |
+| OOM kill | Entire process killed | Only the affected service restarted by systemd/Docker |
+| Network partition (node 2 unreachable) | N/A | Node 1 services continue (data + bot), analysis jobs queue in Redis until node 2 returns |
+
+### 11.2 Graceful Degradation
+
+Each service implements a degradation ladder:
+
+```
+data-gateway:
+  1. Normal: fetch all symbols, publish to Redis
+  2. Degraded (Sensibull down): publish yfinance + Zerodha data only, skip Sensibull
+  3. Degraded (Zerodha WS down): publish REST data only, mark WS as disconnected
+  4. Critical (all data sources down): publish heartbeat only, alert via notification-service
+
+analysis-engine:
+  1. Normal: run all 12 analysers
+  2. Degraded (missing sensibull data): skip options/PCR/IV/OI analysers, run technical only
+  3. Degraded (missing price data): skip all, publish empty result
+
+notification-service:
+  1. Normal: send all alerts
+  2. Degraded (Telegram down): queue in Redis stream, retry every 60s
+  3. Critical (Redis down): log to stdout, systemd journal captures
+```
+
+### 11.3 Circuit Breakers
+
+```python
+# Each service implements a circuit breaker for external calls
+class CircuitBreaker:
+    def __init__(self, failure_threshold=5, recovery_timeout=60):
+        self.failures = 0
+        self.threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.last_failure_time = 0
+        self.state = "closed"  # closed, open, half-open
+
+    def call(self, func, *args, **kwargs):
+        if self.state == "open":
+            if time.time() - self.last_failure_time > self.recovery_timeout:
+                self.state = "half-open"
+            else:
+                raise CircuitBreakerOpenError()
+
+        try:
+            result = func(*args, **kwargs)
+            if self.state == "half-open":
+                self.state = "closed"
+                self.failures = 0
+            return result
+        except Exception:
+            self.failures += 1
+            self.last_failure_time = time.time()
+            if self.failures >= self.threshold:
+                self.state = "open"
+            raise
+```
+
+---
+
+## 12. Observability
+
+### 12.1 Per-Service Health Checks
+
+Each service writes to Redis every 10 seconds:
+
+```redis
+HSET service:registry:data-gateway
+  name "data-gateway"
+  pid 12345
+  status "healthy"          # healthy | degraded | critical | starting
+  last_heartbeat 1234567890
+  version "2.0.0"
+  stats_json '{"ticks_received": 45678, "ticks_published": 45000, "ws_connected": true, "sensibull_ws_connected": true, "cycle_count": 32}'
+EXPIRE service:registry:data-gateway 30
+```
+
+### 12.2 Stream Lag Monitoring
+
+```redis
+# Pending messages per consumer group (high = workers can't keep up)
+XPENDING orchestrator:analysis_jobs analysis-workers
+XPENDING analysis:results notifier
+XPENDING intelligence:signals intelligence
+
+# Stream length (high = not being consumed)
+XLEN orchestrator:analysis_jobs
+XLEN analysis:results
+XLEN intelligence:signals
+```
+
+### 12.3 Structured Logging
+
+Each service logs JSON to stdout (captured by systemd journal):
+
+```json
+{
+  "service": "analysis-engine",
+  "worker_id": 1,
+  "level": "INFO",
+  "event": "analysis_complete",
+  "symbol": "NIFTY",
+  "cycle_id": "2026-06-26-32",
+  "duration_ms": 1250,
+  "signals_fired": 5,
+  "score": 145,
+  "timestamp": "2026-06-26T12:00:00+05:30"
+}
+```
+
+### 12.4 /status Bot Command (Updated)
+
+The `/status` command now reads from Redis service registry:
+
+```
+📊 System Health Dashboard
+
+⏰ Time: 12:00:00  |  📅 Trading Day: Yes ✅
+📡 Mode: INTRADAY  |  🏭 Production: 🟢 ON
+
+🟢 Services (compact mode — 5 processes):
+  🟢 redis: 22 MB / 128 MB
+  🟢 data-gateway: 32 cycles, WS connected, 45K ticks, 850 MB
+  🟢 coordinator: orchestrator + intelligence + bot, 15 confluences, 3 narratives, 500 MB
+  🟢 analysis-engine@1: 50 jobs/cycle, avg 1.2s/job, 420 MB
+  🟢 notification-service: 8 alerts sent, 0 failed, 180 MB
+
+📡 Feed Health:
+  Equity ticks: 🟢 2s ago
+  Options (NIFTY): 🟢 1s ago
+  Options (BANKNIFTY): 🟢 1s ago
+
+💾 Memory (laptop total):
+  Process RSS: 🟢 2.0 GB / 8.0 GB
+  System used: 🟡 52% (avail 3.8 GB)
+
+🤖 LLM Budget:
+  Used today: 🟢 35,000 / 900,000 tokens (3.9%)
+
+📈 Stream Lag:
+  analysis_jobs: 🟢 0 pending
+  analysis:results: 🟢 0 pending
+  intelligence:signals: 🟢 2 pending
+```
+
+---
+
+## 13. Migration Path
+
+### Phase 0: Laptop Prerequisites (1 day)
+
+1. Install Redis on the laptop: `sudo apt install redis-server`
+2. Disable suspend on lid close: edit `/etc/systemd/logind.conf`
+3. Create `services/` directory structure
+4. Create shared `services/common/` package with Redis client, serialization utils, health check mixin
+5. Configure Redis: `configs/redis.conf` (128mb maxmemory, no persistence)
+6. Install systemd units for Redis
+
+### Phase 1A: Extract data-gateway (3-5 days)
+
+**Goal**: Move all data fetching to a separate process that publishes to Redis. This alone solves the 12 PM stall — analysis stays in the monolith but reads data from Redis instead of fetching it inline.
+
+Steps:
+1. Create `services/data-gateway/main.py` — copies ZerodhaTickerManager, SensibullFetcher, yfinance fetch logic
+2. Replace in-process Stock objects with Redis HSET writes
+3. Keep intraday_monitor.py reading from Redis instead of calling fetchers directly
+4. Run data-gateway + monolith in parallel; verify data matches
+5. Remove data fetching code from intraday_monitor.py
+
+**Risk**: TickStore serialization to Redis. Solution: publish only aggregate data (not raw ticks) to Redis; keep TickStore in data-gateway memory.
+
+**After this phase**: The 12 PM stall is fixed. The monolith no longer makes HTTP calls — it just reads from Redis and runs analysers.
+
+### Phase 1B: Extract notification-service (2-3 days)
+
+**Goal**: Move all Telegram/Discord sending to a separate process.
+
+Steps:
+1. Create `services/notification-service/main.py`
+2. Monolith writes to `analysis:results` stream instead of calling TELEGRAM_NOTIFICATIONS directly
+3. notification-service reads stream, applies score gating, formats, sends
+4. Port MessageFormatter.py logic to notification-service
+
+### Phase 1C: Extract analysis-engine (3-5 days)
+
+**Goal**: Move all 12 analysers to worker processes. This is the big one — it replaces the ThreadPoolExecutor.
+
+Steps:
+1. Create `services/analysis-engine/main.py`
+2. Worker reads job from `orchestrator:analysis_jobs` stream
+3. Reconstructs Stock object from Redis hashes (priceData, sensibull_ctx, zerodha_ctx)
+4. Runs AnalyserOrchestrator.run_all_intraday() — same code, no changes to analysers
+5. Publishes result to `analysis:results` stream
+6. Orchestrator in monolith writes jobs to stream instead of running ThreadPoolExecutor
+
+**Key**: Stock object reconstruction. Create a `Stock.from_redis(redis_client, symbol)` classmethod that reads all Redis hashes and populates the Stock fields. The analysers don't know the difference.
+
+### Phase 1D: Extract coordinator (compact mode) (3-5 days)
+
+**Goal**: Replace intraday_monitor.py's main loop with a coordinator service that runs orchestrator + intelligence + bot in one process (compact mode for laptop).
+
+Steps:
+1. Create `services/coordinator/main.py` — runs 3 asyncio tasks concurrently:
+   - Orchestrator task: cycle timing, mode selection, holiday check, emits `cycle_trigger` + `analysis_jobs`
+   - Intelligence task: subscribes to `analysis:results` + `intelligence:signals`, runs correlator + narrator
+   - Bot task: Telegram bot polling, reads from Redis for commands
+2. All three share the same Redis connection (reduces socket count on laptop)
+3. If any task crashes, only that task restarts (asyncio task cancellation + recreation)
+4. When you get a second machine, you split this into 3 separate services (zero code changes — just run the 3 main.py entry points separately)
+
+### Phase 1E: Extract auth-service (1 day)
+
+**Goal**: Move TOTP login to separate process.
+
+Steps:
+1. Create `services/auth-service/main.py`
+2. auth-service listens on `auth:commands` stream for refresh requests
+3. On refresh: runs TOTP login, writes enctoken to Redis, publishes to `auth:enctoken_refreshed`
+4. data-gateway subscribes to `auth:enctoken_refreshed` and reconnects
+
+### Phase 1 Complete: Decommission Monolith
+
+After all services are extracted:
+1. Delete `intraday/intraday_monitor.py` (or keep as legacy reference)
+2. Delete `common/shared.py` AppContext (replaced by Redis)
+3. Update Makefile targets to manage systemd services
+4. Update CLAUDE.md with new architecture
+5. **5 processes running on laptop**: Redis, data-gateway, analysis-engine@1, coordinator, notification-service
+6. **3.3 GB RAM headroom**: enough for a second analysis worker if needed
+
+### Future: Split coordinator into separate services (when you get a 2nd machine)
+
+When you add a second machine, split the coordinator into 3 separate services:
+1. `services/orchestrator/main.py` — standalone orchestrator
+2. `services/intelligence-service/main.py` — standalone intelligence
+3. `services/bot-service/main.py` — standalone bot
+
+The coordinator's `main.py` already imports these modules — splitting is just running them as separate processes instead of asyncio tasks. Zero code changes to the individual modules.
+
+### Migration Timeline
+
+| Phase | Duration | Deliverable | Risk | 12 PM stall fixed? |
+|-------|----------|------------|------|-------------------|
+| 0: Laptop setup | 1 day | Redis + service scaffold | Low | No |
+| 1A: data-gateway | 3-5 days | Data fetching isolated | Medium (TickStore serialization) | **Yes** |
+| 1B: notification | 2-3 days | Notifications isolated | Low | Yes |
+| 1C: analysis-engine | 3-5 days | Analysis isolated (no ThreadPoolExecutor) | Medium (Stock reconstruction) | Yes |
+| 1D: coordinator | 3-5 days | Monolith decommissioned | Medium (3 asyncio tasks) | Yes |
+| 1E: auth-service | 1 day | Auth isolated | Low | Yes |
+| **Total** | **~15 days** | **Full microservices on laptop** | | |
+
+> **Phase 1A alone fixes the stall.** The remaining phases are about clean architecture and future-proofing. You can stop after 1A and the 12 PM problem is solved — the monolith just reads from Redis instead of doing HTTP calls.
+
+---
+
+## 14. Service Stub Specifications
+
+### 14.1 Directory Structure
+
+```
+StockAnalysis/
+├── services/
+│   ├── __init__.py
+│   ├── common/                   # Shared service infrastructure
+│   │   ├── __init__.py
+│   │   ├── redis_client.py       # Redis connection manager (async)
+│   │   ├── serialization.py      # DataFrame/dict serialization helpers
+│   │   ├── health.py             # Health check mixin (heartbeat to Redis)
+│   │   ├── circuit_breaker.py    # Circuit breaker for external calls
+│   │   ├── stream_consumer.py    # Base class for stream consumers
+│   │   └── stock_proxy.py        # Stock.from_redis() / Stock.to_redis()
+│   │
+│   ├── data-gateway/
+│   │   ├── __init__.py
+│   │   ├── main.py               # Entry point: asyncio loop
+│   │   ├── yfinance_fetcher.py   # Async yfinance data fetcher
+│   │   ├── zerodha_manager.py    # WebSocket + REST (ported from zerodha/)
+│   │   ├── sensibull_fetcher.py  # REST fetcher (ported from fno/)
+│   │   ├── sensibull_feed.py     # WebSocket feed (ported from fno/)
+│   │   ├── tick_store.py         # TickStore (ported from zerodha/)
+│   │   ├── token_registry.py     # Token registry (ported from common/)
+│   │   └── publisher.py          # Redis publish logic
+│   │
+│   ├── coordinator/                  # COMPACT MODE: merged orchestrator + intelligence + bot
+│   │   ├── __init__.py
+│   │   ├── main.py               # Entry point: runs 3 asyncio tasks in one process
+│   │   ├── cycle_manager.py      # Cycle trigger + completion tracking (from orchestrator)
+│   │   ├── mode_selector.py      # Intraday/positional/premarket routing
+│   │   ├── signal_bus.py         # Redis-backed SignalBus (from intelligence)
+│   │   ├── correlator.py         # Ported from intelligence/correlator.py
+│   │   ├── narrator.py           # Ported from intelligence/narrator.py
+│   │   ├── llm_client.py         # Ported from intelligence/llm_client.py
+│   │   ├── context_builder.py    # Ported from intelligence/context_builder.py (reads Redis)
+│   │   ├── commands/             # Ported from notification/commands/
+│   │   └── redis_reader.py       # Reads live data from Redis for bot commands
+│   │
+│   ├── orchestrator/                 # FULL MODE: separate orchestrator
+│   │   ├── __init__.py
+│   │   ├── main.py               # Entry point: cycle scheduler
+│   │   ├── cycle_manager.py      # Cycle trigger + completion tracking
+│   │   └── mode_selector.py      # Intraday/positional/premarket routing
+│   │
+│   ├── analysis-engine/
+│   │   ├── __init__.py
+│   │   ├── main.py               # Entry point: stream consumer loop
+│   │   ├── worker.py             # Job processor: reconstruct Stock, run analysers
+│   │   ├── analysers/            # Symlink or import from ../../analyser/
+│   │   └── scoring.py            # Import from ../../common/scoring.py
+│   │
+│   ├── intelligence-service/         # FULL MODE: separate intelligence
+│   │   ├── __init__.py
+│   │   ├── main.py               # Entry point: signal consumer + correlator
+│   │   ├── signal_bus.py         # Redis-backed SignalBus
+│   │   ├── correlator.py         # Ported from intelligence/correlator.py
+│   │   ├── narrator.py           # Ported from intelligence/narrator.py
+│   │   ├── llm_client.py         # Ported from intelligence/llm_client.py
+│   │   └── context_builder.py    # Ported from intelligence/context_builder.py (reads Redis)
+│   │
+│   ├── notification-service/
+│   │   ├── __init__.py
+│   │   ├── main.py               # Entry point: multi-stream consumer
+│   │   ├── formatter.py          # Ported from analyser/MessageFormatter.py
+│   │   ├── telegram_sender.py    # Ported from notification/Notification.py
+│   │   ├── discord_sender.py     # Discord webhook sender
+│   │   └── score_gate.py         # Ported from common/scoring.py should_notify()
+│   │
+│   ├── bot-service/                  # FULL MODE: separate bot
+│   │   ├── __init__.py
+│   │   ├── main.py               # Entry point: Telegram bot
+│   │   ├── commands/             # Ported from notification/commands/
+│   │   └── redis_reader.py       # Reads live data from Redis for commands
+│   │
+│   └── auth-service/
+│       ├── __init__.py
+│       └── main.py               # Entry point: TOTP login + command listener
+│
+├── analyser/                     # UNCHANGED — imported by analysis-engine
+├── common/                       # SHARED — constants, scoring, Stock model
+├── configs/
+│   ├── redis.conf                # Redis configuration
+│   └── service_env/              # Per-service .env files
+│       ├── data-gateway.env
+│       ├── orchestrator.env
+│       ├── analysis-engine.env
+│       └── ...
+├── scripts/
+│   ├── system_config/            # systemd unit files
+│   │   ├── stockanalysis-redis.service
+│   │   ├── stockanalysis-data-gateway.service
+│   │   ├── stockanalysis-coordinator.service       # COMPACT mode (merged)
+│   │   ├── stockanalysis-orchestrator.service       # FULL mode (separate)
+│   │   ├── stockanalysis-analysis@.service          # Workers (template)
+│   │   ├── stockanalysis-intelligence.service       # FULL mode (separate)
+│   │   ├── stockanalysis-notification.service
+│   │   ├── stockanalysis-bot.service                # FULL mode (separate)
+│   │   ├── stockanalysis-auth.service
+│   │   ├── stockanalysis-auth.timer
+│   │   ├── stockanalysis.timer
+│   │   └── stockanalysis-positional.timer
+│   ├── deploy_services.py        # Deploy script for multi-service setup
+│   └── laptop_setup.sh           # One-time laptop setup (suspend disable, Redis, etc)
+└── Makefile                      # Updated with service management targets
+```
+
+### 14.2 Shared Service Base Class
+
+```python
+# services/common/stream_consumer.py
+import asyncio
+import json
+import time
+import signal
+from abc import ABC, abstractmethod
+from redis.asyncio import Redis
+from common.logging_util import logger
+
+
+class StreamConsumer(ABC):
+    """Base class for Redis Stream consumers with consumer groups."""
+
+    def __init__(
+        self,
+        redis: Redis,
+        stream: str,
+        group: str,
+        consumer_name: str,
+        batch_size: int = 10,
+        block_ms: int = 5000,
+        ack_timeout: int = 120,
+    ):
+        self.redis = redis
+        self.stream = stream
+        self.group = group
+        self.consumer = consumer_name
+        self.batch_size = batch_size
+        self.block_ms = block_ms
+        self.ack_timeout = ack_timeout
+        self._running = False
+
+    async def start(self):
+        self._running = True
+        await self._ensure_group()
+        await self._reclaim_stale_messages()
+
+        while self._running:
+            try:
+                messages = await self.redis.xreadgroup(
+                    groupname=self.group,
+                    consumername=self.consumer,
+                    streams={self.stream: ">"},
+                    count=self.batch_size,
+                    block=self.block_ms,
+                )
+                for stream, msg_id, fields in messages:
+                    await self._process(msg_id, fields)
+                    await self.redis.xack(self.stream, self.group, msg_id)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"[{self.consumer}] Stream error: {e}")
+                await asyncio.sleep(1)
+
+    async def stop(self):
+        self._running = False
+
+    async def _ensure_group(self):
+        try:
+            await self.redis.xgroup_create(self.stream, self.group, "$", mkstream=True)
+        except Exception:
+            pass  # Group already exists
+
+    async def _reclaim_stale_messages(self):
+        """XCLAIM messages from dead consumers."""
+        pending = await self.redis.xpending_range(
+            self.stream, self.group, min="-", max="+", count=100
+        )
+        now = time.time()
+        for entry in pending:
+            if entry["time_since_delivered"] > self.ack_timeout * 1000:
+                claimed = await self.redis.xclaim(
+                    self.stream, self.group, self.consumer,
+                    min_idle_time=self.ack_timeout * 1000,
+                    message_ids=[entry["message_id"]],
+                )
+                for msg_id, fields in claimed:
+                    logger.warning(f"[{self.consumer}] Reclaimed stale message {msg_id}")
+                    await self._process(msg_id, fields)
+                    await self.redis.xack(self.stream, self.group, msg_id)
+
+    @abstractmethod
+    async def _process(self, msg_id: str, fields: dict):
+        """Process a single message. Override in subclass."""
+        ...
+```
+
+### 14.3 Stock Proxy (Redis ↔ Stock Object)
+
+```python
+# services/common/stock_proxy.py
+import json
+import pandas as pd
+from redis.asyncio import Redis
+from common.Stock import Stock
+
+
+class StockProxy:
+    """Reconstructs Stock objects from Redis for analysis-engine workers."""
+
+    @staticmethod
+    async def from_redis(redis: Redis, symbol: str, is_index: bool = False) -> Stock:
+        stock = Stock(symbol, symbol, is_index=is_index)
+
+        # Price data
+        price_data = await redis.hgetall(f"data:price:{symbol}")
+        if price_data:
+            stock.priceData = pd.read_json(
+                price_data["priceData_json"], orient="split"
+            )
+            stock.ltp = float(price_data.get("ltp", 0))
+            stock.ltp_change_perc = float(price_data.get("ltp_change_perc", 0))
+            if "prevDayOHLCV_json" in price_data:
+                stock.prevDayOHLCV = json.loads(price_data["prevDayOHLCV_json"])
+            if "daily_hv" in price_data:
+                stock.daily_hv = float(price_data["daily_hv"])
+
+        # Sensibull context
+        sensibull_data = await redis.hgetall(f"data:sensibull:{symbol}")
+        if sensibull_data:
+            stock.sensibull_ctx = {
+                "last_fetch_time": sensibull_data.get("last_fetch_time"),
+                "current": json.loads(sensibull_data.get("current_json", "{}")),
+                "historical_data": pd.read_json(
+                    sensibull_data.get("historical_data_json", "{}"), orient="split"
+                ) if "historical_data_json" in sensibull_data else pd.DataFrame(),
+                "oi_chain": json.loads(sensibull_data.get("oi_chain_json", "null")),
+                "oi_chain_history": json.loads(
+                    sensibull_data.get("oi_chain_history_json", "[]")
+                ),
+                "iv_chart_history": pd.read_json(
+                    sensibull_data.get("iv_chart_history_json", "{}"), orient="split"
+                ) if "iv_chart_history_json" in sensibull_data else pd.DataFrame(),
+                "oi_history": pd.read_json(
+                    sensibull_data.get("oi_history_json", "{}"), orient="split"
+                ) if "oi_history_json" in sensibull_data else pd.DataFrame(),
+            }
+
+        # Zerodha context
+        zerodha_data = await redis.hgetall(f"data:zerodha:{symbol}")
+        if zerodha_data:
+            stock.zerodha_ctx = {
+                "last_notification_time": None,
+                "option_chain": {
+                    "current": pd.read_json(
+                        zerodha_data["option_chain_current_json"], orient="split"
+                    ) if "option_chain_current_json" in zerodha_data else None,
+                    "next": None,
+                },
+                "futures_mdata": json.loads(
+                    zerodha_data.get("futures_mdata_json", "{}")
+                ),
+                "futures_data": {
+                    "current": pd.read_json(
+                        zerodha_data.get("futures_data_current_json", "{}"),
+                        orient="split",
+                    ) if "futures_data_current_json" in zerodha_data else pd.DataFrame(),
+                    "next": pd.DataFrame(),
+                },
+            }
+
+        return stock
+
+    @staticmethod
+    async def get_options_live(redis: Redis, symbol: str) -> dict:
+        """Read live options data from Redis."""
+        raw = await redis.hgetall(f"data:options_live:{symbol}")
+        options_live = {}
+        for key, value in raw.items():
+            # key format: "{strike}_{CE|PE}"
+            parts = key.rsplit("_", 1)
+            if len(parts) == 2:
+                strike = float(parts[0])
+                opt_type = parts[1]
+                if strike not in options_live:
+                    options_live[strike] = {}
+                options_live[strike][opt_type] = json.loads(value)
+        return options_live
+
+    @staticmethod
+    async def get_options_aggregate(redis: Redis, symbol: str) -> dict:
+        """Read live options aggregate from Redis."""
+        raw = await redis.hgetall(f"data:options_agg:{symbol}")
+        return {k: json.loads(v) if v.startswith("{") else v for k, v in raw.items()}
+```
+
+### 14.4 analysis-engine Worker Stub
+
+```python
+# services/analysis-engine/main.py
+import asyncio
+import gc
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from redis.asyncio import Redis
+from common.logging_util import logger
+from services.common.stream_consumer import StreamConsumer
+from services.common.stock_proxy import StockProxy
+from analyser.Analyser import AnalyserOrchestrator
+from analyser.VolumeAnalyser import VolumeAnalyser
+from analyser.TechnicalAnalyser import TechnicalAnalyser
+from analyser.candleStickPatternAnalyser import CandleStickAnalyser
+from analyser.IVAnalyser import IVAnalyser
+from analyser.Futures_Analyser import FuturesAnalyser
+from analyser.PCRAnalyser import PCRAnalyser
+from analyser.MaxPainAnalyser import MaxPainAnalyser
+from analyser.OIChainAnalyser import OIChainAnalyser
+from analyser.GEXAnalyser import GEXAnalyser
+from analyser.PanicModeAnalyser import PanicModeAnalyser
+from analyser.OptionSellerCompositeAnalyser import OptionSellerCompositeAnalyser
+from common.scoring import should_notify, calculate_score
+
+
+class AnalysisWorker(StreamConsumer):
+    def __init__(self, redis: Redis, worker_id: str):
+        super().__init__(
+            redis=redis,
+            stream="orchestrator:analysis_jobs",
+            group="analysis-workers",
+            consumer_name=f"worker-{worker_id}",
+            batch_size=1,
+            block_ms=2000,
+            ack_timeout=120,
+        )
+        self.orchestrator = self._build_orchestrator()
+
+    def _build_orchestrator(self) -> AnalyserOrchestrator:
+        orch = AnalyserOrchestrator()
+        orch.register(VolumeAnalyser())
+        orch.register(TechnicalAnalyser())
+        orch.register(CandleStickAnalyser())
+        orch.register(IVAnalyser())
+        orch.register(FuturesAnalyser())
+        orch.register(PCRAnalyser())
+        orch.register(MaxPainAnalyser())
+        orch.register(OIChainAnalyser())
+        orch.register(GEXAnalyser())
+        orch.register(PanicModeAnalyser())
+        orch.register(OptionSellerCompositeAnalyser())
+        return orch
+
+    async def _process(self, msg_id: str, fields: dict):
+        symbol = fields["symbol"]
+        mode = fields["mode"]
+        cycle_id = fields["cycle_id"]
+
+        logger.info(f"[worker] Processing {symbol} for cycle {cycle_id}")
+
+        try:
+            stock = await StockProxy.from_redis(
+                self.redis, symbol, is_index=(fields.get("is_index") == "true")
+            )
+
+            if mode == "intraday":
+                self.orchestrator.run_all_intraday(stock)
+            else:
+                self.orchestrator.run_all_positional(stock)
+
+            score_result = calculate_score(stock.analysis)
+            should_send, score_result = should_notify(stock.analysis)
+
+            result = {
+                "job_id": fields.get("job_id", msg_id),
+                "cycle_id": cycle_id,
+                "symbol": symbol,
+                "mode": mode,
+                "analysis": json.dumps(stock.analysis, default=str),
+                "score_result": json.dumps({
+                    "total_score": score_result.total_score,
+                    "priority": score_result.priority.value,
+                    "dominant_sentiment": score_result.dominant_sentiment,
+                    "confidence_pct": score_result.confidence_pct,
+                    "should_notify": should_send,
+                }, default=str),
+                "timestamp": str(asyncio.get_event_loop().time()),
+            }
+
+            await self.redis.xadd("analysis:results", result)
+            await self.redis.hset(
+                f"analysis:latest:{symbol}",
+                mapping={
+                    "analysis_json": result["analysis"],
+                    "score_result_json": result["score_result"],
+                    "timestamp": result["timestamp"],
+                },
+            )
+
+            logger.info(
+                f"[worker] {symbol} done: score={score_result.total_score}, "
+                f"priority={score_result.priority.value}, notify={should_send}"
+            )
+
+        except Exception as e:
+            logger.error(f"[worker] {symbol} failed: {e}", exc_info=True)
+            await self.redis.xadd("analysis:errors", {
+                "job_id": fields.get("job_id", msg_id),
+                "symbol": symbol,
+                "error": str(e),
+                "timestamp": str(asyncio.get_event_loop().time()),
+            })
+
+        finally:
+            gc.collect()  # Prevent gen-2 accumulation across symbols
+
+
+async def main():
+    worker_id = os.environ.get("WORKER_ID", "1")
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+    redis = Redis.from_url(redis_url, decode_responses=True)
+
+    worker = AnalysisWorker(redis, worker_id)
+
+    # Graceful shutdown
+    loop = asyncio.get_event_loop()
+    stop_event = asyncio.Event()
+
+    def _signal_handler():
+        stop_event.set()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _signal_handler)
+
+    logger.info(f"[worker-{worker_id}] Starting analysis worker")
+
+    # Start consumer and health check concurrently
+    consumer_task = asyncio.create_task(worker.start())
+    stop_task = asyncio.create_task(stop_event.wait())
+
+    await asyncio.wait([consumer_task, stop_task], return_when=asyncio.FIRST_COMPLETED)
+    await worker.stop()
+    consumer_task.cancel()
+    await redis.aclose()
+    logger.info(f"[worker-{worker_id}] Shut down cleanly")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### 14.5 Coordinator Service Stub (Compact Mode — Laptop)
+
+```python
+# services/coordinator/main.py
+"""
+Compact mode entry point — runs orchestrator + intelligence + bot
+in a single asyncio process. Saves ~500MB RAM vs 3 separate processes.
+
+When you get a second machine, split this into 3 separate services:
+  - services/orchestrator/main.py
+  - services/intelligence-service/main.py
+  - services/bot-service/main.py
+
+The modules (cycle_manager, correlator, narrator, commands) are the
+SAME code — just run as separate processes instead of asyncio tasks.
+Zero code changes needed to split.
+"""
+import asyncio
+import os
+import signal
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from redis.asyncio import Redis
+from common.logging_util import logger
+
+# Import the three sub-modules (shared code, same files as standalone mode)
+from services.coordinator.cycle_manager import CycleManager
+from services.coordinator.signal_bus import RedisSignalBus
+from services.coordinator.correlator import RedisCorrelator
+from services.coordinator.narrator import MarketNarrator
+from services.coordinator.llm_client import GeminiClient
+from services.coordinator.context_builder import ContextBuilder
+from services.coordinator.commands import register_all as register_bot_commands
+
+
+async def main():
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+    redis = Redis.from_url(redis_url, decode_responses=True)
+
+    stop_event = asyncio.Event()
+
+    def _signal_handler():
+        logger.info("[coordinator] Shutdown signal received")
+        stop_event.set()
+
+    loop = asyncio.get_event_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _signal_handler)
+
+    # ── Task 1: Orchestrator (cycle scheduling) ──────────────────────────
+    cycle_mgr = CycleManager(redis)
+    orchestrator_task = asyncio.create_task(
+        cycle_mgr.run(stop_event), name="orchestrator"
+    )
+
+    # ── Task 2: Intelligence (signal correlation + LLM) ──────────────────
+    signal_bus = RedisSignalBus(redis)
+    llm_client = GeminiClient()
+    context_builder = ContextBuilder(redis)
+    correlator = RedisCorrelator(redis, signal_bus)
+    narrator = MarketNarrator(llm_client, context_builder)
+    intelligence_task = asyncio.create_task(
+        _run_intelligence(redis, signal_bus, correlator, narrator, stop_event),
+        name="intelligence"
+    )
+
+    # ── Task 3: Bot (Telegram commands) ──────────────────────────────────
+    bot_task = asyncio.create_task(
+        _run_bot(redis, stop_event), name="bot"
+    )
+
+    logger.info("[coordinator] Started: orchestrator + intelligence + bot")
+
+    # Wait for any task to fail or stop signal
+    all_tasks = [orchestrator_task, intelligence_task, bot_task]
+    done, pending = await asyncio.wait(
+        all_tasks + [asyncio.create_task(stop_event.wait())],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    # Cancel remaining tasks
+    for task in pending:
+        task.cancel()
+
+    await asyncio.gather(*pending, return_exceptions=True)
+    await redis.aclose()
+    logger.info("[coordinator] Shut down cleanly")
+
+
+async def _run_intelligence(redis, signal_bus, correlator, narrator, stop_event):
+    """Consume signals, detect confluences, generate narratives."""
+    while not stop_event.is_set():
+        try:
+            signals = await signal_bus.read_batch(count=10, block=2000)
+            for signal in signals:
+                confluence = correlator.on_signal(signal)
+                if confluence and confluence.level == "HIGH":
+                    narrator.narrate_async(confluence)
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.error(f"[intelligence] Error: {e}")
+            await asyncio.sleep(1)
+
+
+async def _run_bot(redis, stop_event):
+    """Run Telegram bot polling — reads from Redis for command data."""
+    from telegram.ext import ApplicationBuilder
+    from common.constants import TELEGRAM_INTRADAY_TOKEN
+
+    app = ApplicationBuilder().token(TELEGRAM_INTRADAY_TOKEN).build()
+    register_bot_commands(app, redis)
+
+    try:
+        await app.initialize()
+        await app.start()
+        await app.updater.start_polling()
+        await stop_event.wait()
+    finally:
+        await app.updater.stop()
+        await app.stop()
+        await app.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### 14.6 Updated Makefile Targets
+
+```makefile
+# ─── Service Management ─────────────────────────────────────────────────────
+
+# Redis
+.PHONY: redis-start redis-stop redis-status redis-cli
+redis-start:
+	sudo systemctl start stockanalysis-redis
+redis-stop:
+	sudo systemctl stop stockanalysis-redis
+redis-status:
+	sudo systemctl status stockanalysis-redis
+redis-cli:
+	redis-cli -h localhost -p 6379
+
+# Individual services
+.PHONY: svc-start svc-stop svc-restart svc-status svc-logs
+svc-start:
+	@test -n "$(SVC)" || { echo "Usage: make svc-start SVC=data-gateway"; exit 1; }
+	sudo systemctl start stockanalysis-$(SVC)
+svc-stop:
+	@test -n "$(SVC)" || { echo "Usage: make svc-stop SVC=data-gateway"; exit 1; }
+	sudo systemctl stop stockanalysis-$(SVC)
+svc-restart:
+	@test -n "$(SVC)" || { echo "Usage: make svc-restart SVC=data-gateway"; exit 1; }
+	sudo systemctl restart stockanalysis-$(SVC)
+svc-status:
+	@test -n "$(SVC)" || { echo "Usage: make svc-status SVC=data-gateway"; exit 1; }
+	sudo systemctl status stockanalysis-$(SVC)
+svc-logs:
+	@test -n "$(SVC)" || { echo "Usage: make svc-logs SVC=data-gateway"; exit 1; }
+	journalctl -u stockanalysis-$(SVC) -n 50 --no-pager
+
+# Analysis workers (template unit)
+.PHONY: workers-start workers-stop workers-scale
+workers-start:
+	sudo systemctl start stockanalysis-analysis@1
+	sudo systemctl start stockanalysis-analysis@2
+workers-stop:
+	sudo systemctl stop stockanalysis-analysis@1
+	sudo systemctl stop stockanalysis-analysis@2
+workers-scale:
+	@test -n "$(N)" || { echo "Usage: make workers-scale N=3"; exit 1; }
+	@for i in $$(seq 1 $(N)); do sudo systemctl start stockanalysis-analysis@$$i; done
+
+# All services — COMPACT mode (single laptop, 5 processes)
+.PHONY: svc-start-all svc-stop-all svc-status-all
+svc-start-all:
+	sudo systemctl start stockanalysis-redis
+	sudo systemctl start stockanalysis-data-gateway
+	sudo systemctl start stockanalysis-coordinator
+	sudo systemctl start stockanalysis-analysis@1
+	sudo systemctl start stockanalysis-notification
+svc-stop-all:
+	sudo systemctl stop stockanalysis-notification
+	sudo systemctl stop stockanalysis-analysis@1
+	sudo systemctl stop stockanalysis-coordinator
+	sudo systemctl stop stockanalysis-data-gateway
+	sudo systemctl stop stockanalysis-redis
+svc-status-all:
+	@for svc in redis data-gateway coordinator analysis@1 notification; do
+		echo "--- stockanalysis-$$svc ---"
+		systemctl is-active stockanalysis-$$svc 2>/dev/null || echo "not loaded"
+	done
+
+# All services — FULL mode (when splitting coordinator into separate services)
+.PHONY: svc-start-full svc-stop-full svc-status-full
+svc-start-full:
+	sudo systemctl start stockanalysis-redis
+	sudo systemctl start stockanalysis-data-gateway
+	sudo systemctl start stockanalysis-orchestrator
+	sudo systemctl start stockanalysis-analysis@1
+	sudo systemctl start stockanalysis-intelligence
+	sudo systemctl start stockanalysis-notification
+	sudo systemctl start stockanalysis-bot
+svc-stop-full:
+	sudo systemctl stop stockanalysis-bot
+	sudo systemctl stop stockanalysis-notification
+	sudo systemctl stop stockanalysis-intelligence
+	sudo systemctl stop stockanalysis-analysis@1
+	sudo systemctl stop stockanalysis-orchestrator
+	sudo systemctl stop stockanalysis-data-gateway
+	sudo systemctl stop stockanalysis-redis
+svc-status-full:
+	@for svc in redis data-gateway orchestrator analysis@1 intelligence notification bot; do
+		echo "--- stockanalysis-$$svc ---"
+		systemctl is-active stockanalysis-$$svc 2>/dev/null || echo "not loaded"
+	done
+
+# Redis stream inspection
+.PHONY: stream-info stream-pending stream-lag
+stream-info:
+	@echo "Stream lengths:"
+	@for s in orchestrator:cycle_trigger orchestrator:analysis_jobs \
+	          analysis:results intelligence:signals intelligence:narratives \
+	          intelligence:confluences; do
+		echo "  $$s: $$(redis-cli XLEN $$s)"
+	done
+stream-pending:
+	@for s in orchestrator:analysis_jobs analysis:results intelligence:signals; do
+		echo "=== $$s ==="
+		redis-cli XPENDING $$s analysis-workers 2>/dev/null || \
+		redis-cli XPENDING $$s notifier 2>/dev/null || \
+		redis-cli XPENDING $$s intelligence 2>/dev/null || echo "  no group"
+	done
+
+# Deploy (updated for multi-service)
+.PHONY: deploy-services
+deploy-services:
+	PYTHONPATH=$(CURDIR) $(PYTHON) scripts/deploy_services.py
+
+# Laptop setup (one-time)
+.PHONY: laptop-setup
+laptop-setup:
+	@echo "Configuring laptop for 24/7 service operation..."
+	sudo cp configs/redis.conf /etc/redis/redis.conf
+	sudo systemctl restart redis
+	@echo "Disabling suspend on lid close..."
+	sudo sed -i 's/^#HandleLidSwitch=.*/HandleLidSwitch=ignore/' /etc/systemd/logind.conf
+	sudo sed -i 's/^#HandleLidSwitchExternalPower=.*/HandleLidSwitchExternalPower=ignore/' /etc/systemd/logind.conf
+	sudo systemctl restart systemd-logind
+	@echo "Installing systemd units..."
+	sudo cp scripts/system_config/stockanalysis-*.service /etc/systemd/system/
+	sudo cp scripts/system_config/stockanalysis-*.timer /etc/systemd/system/
+	sudo systemctl daemon-reload
+	@echo "Done. Run 'make svc-start-all' to start."
+```
+
+---
+
+## Appendix A: Monolith → Microservices Mapping
+
+| Monolith Component | Microservices Destination | Change |
+|--------------------|--------------------------|--------|
+| `intraday/intraday_monitor.py` main loop | `services/coordinator/main.py` (compact) or `services/orchestrator/main.py` (full) | Cycle logic extracted |
+| `intraday/intraday_monitor.py` crash handler | Each service's `main.py` | Per-service exception handling |
+| `intraday/intraday_monitor.py` zombie watchdog | `services/coordinator/` or `services/orchestrator/` | Reads `data:options_agg:*` timestamps from Redis |
+| `common/shared.py` AppContext | Redis hashes + per-service env vars | Global singleton eliminated |
+| `common/Stock.py` | `services/common/stock_proxy.py` | Redis-backed reconstruction |
+| `zerodha/zerodha_analysis.py` | `services/data-gateway/zerodha_manager.py` | Publishes ticks to Redis |
+| `zerodha/tick_store.py` | `services/data-gateway/tick_store.py` | In-memory in data-gateway, aggregate published to Redis |
+| `zerodha/futures_fetcher.py` | `services/data-gateway/` | Called by data-gateway, results to Redis |
+| `zerodha/live_options_engine.py` | `services/coordinator/` (compact) or `services/intelligence-service/` (full) | Reads from Redis pub/sub, emits signals to stream |
+| `zerodha/live_stock_engine.py` | `services/coordinator/` (compact) or `services/intelligence-service/` (full) | Reads from Redis pub/sub, emits signals to stream |
+| `fno/sensibull_fetcher.py` | `services/data-gateway/sensibull_fetcher.py` | Async HTTP, results to Redis |
+| `fno/sensibull_feed.py` | `services/data-gateway/sensibull_feed.py` | Publishes to Redis |
+| `analyser/*.py` (12 analysers) | `services/analysis-engine/` | **Unchanged** — imported as-is |
+| `analyser/Analyser.py` | `services/analysis-engine/` | **Unchanged** |
+| `common/scoring.py` | `services/analysis-engine/` + `services/notification-service/` | Imported as-is |
+| `common/constants.py` | Shared `common/` package | **Unchanged** |
+| `intelligence/signal_bus.py` | `services/coordinator/signal_bus.py` (compact) or `services/intelligence-service/` (full) | In-memory → Redis Stream |
+| `intelligence/correlator.py` | `services/coordinator/correlator.py` (compact) or `services/intelligence-service/` (full) | Buffer in Redis ZSet |
+| `intelligence/narrator.py` | `services/coordinator/narrator.py` (compact) or `services/intelligence-service/` (full) | Async LLM calls |
+| `intelligence/context_builder.py` | `services/coordinator/context_builder.py` (compact) or `services/intelligence-service/` (full) | Reads from Redis instead of shared.app_ctx |
+| `intelligence/llm_client.py` | `services/coordinator/llm_client.py` (compact) or `services/intelligence-service/` (full) | Budget in Redis |
+| `notification/Notification.py` | `services/notification-service/telegram_sender.py` | Consumes from stream |
+| `notification/bot_listener.py` | `services/coordinator/main.py` (compact) or `services/bot-service/main.py` (full) | Reads from Redis |
+| `notification/commands/*.py` | `services/coordinator/commands/` (compact) or `services/bot-service/commands/` (full) | Reads from Redis |
+| `premarket/premarket_report.py` | `services/data-gateway/` | Publishes to `premarket:reports` stream |
+| `post_market_analysis/` | `services/analysis-engine/` (positional mode) | Publishes to `postmarket:reports` stream |
+| `auth/auth_login.py` | `services/auth-service/main.py` | Listens on `auth:commands` stream |
+| `scripts/deploy.py` | `scripts/deploy_services.py` | Multi-service deployment |
+| `scripts/service_stop.py` | Updated for multi-service | Stop all services |
+| `backtest/` | Stays standalone | Not part of real-time services |
+| `ml_pipeline/` | Stays standalone | Not part of real-time services |
+| `sentiment/` | Stays standalone or → `services/sentiment-service/` | Phase 2 |
+
+## Appendix B: Redis Configuration
+
+```redis
+# configs/redis.conf — tuned for 8 GB laptop
+bind 127.0.0.1                    # localhost only in Phase 1 (no password needed)
+# When exposing to network (Phase 2): uncomment these:
+# bind 127.0.0.1 <laptop-lan-ip>
+# requirepass <a-strong-password>
+port 6379
+maxmemory 128mb                   # Tight budget for laptop (was 256mb for server)
+maxmemory-policy allkeys-lru
+save ""                           # No disk persistence (state is ephemeral, saves SSD wear)
+appendonly no                     # No AOF (saves disk + CPU on laptop)
+timeout 0                         # No client timeout
+tcp-keepalive 60                  # Keepalive for long connections
+hz 10                             # Background task frequency
+lazyfree-lazy-eviction yes        # Async eviction for large keys
+lazyfree-lazy-expire yes          # Async expiry
+notify-keyspace-events ""         # Disable keyspace notifications (not needed)
+io-threads 1                      # Single IO thread (laptop has few cores)
+```
+
+## Appendix C: Systemd Unit Templates
+
+### Analysis worker (template — scales by starting @1, @2, @3...)
+
+```ini
+# /etc/systemd/system/stockanalysis-analysis@.service
+[Unit]
+Description=StockAnalysis Analysis Worker (%i)
+Requires=stockanalysis-redis.service
+After=stockanalysis-redis.service
+
+[Service]
+Type=simple
+User=hacker
+WorkingDirectory=/home/hacker/StockAnalysis
+Environment=PYTHONPATH=/home/hacker/StockAnalysis
+Environment=WORKER_ID=%i
+Environment=REDIS_URL=redis://localhost:6379
+EnvironmentFile=/home/hacker/StockAnalysis/.env
+ExecStart=/home/hacker/StockAnalysis/.venv/bin/python -m services.analysis_engine.main
+Restart=always
+RestartSec=10
+StartLimitBurst=5
+StartLimitIntervalSec=300
+StandardOutput=journal
+StandardError=journal
+
+# Laptop thermal protection — don't pin CPU at 100%
+CPUQuota=75%
+CPUWeight=50
+
+# Memory protection — OOM-kill this service, not the laptop
+MemoryMax=800M
+MemorySwapMax=256M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Data gateway (highest priority — holds WebSocket connections)
+
+```ini
+# /etc/systemd/system/stockanalysis-data-gateway.service
+[Unit]
+Description=StockAnalysis Data Gateway
+Requires=stockanalysis-redis.service
+After=stockanalysis-redis.service
+# Prevent laptop suspend while data-gateway is running
+Conflicts=suspend.target hibernate.target hybrid-sleep.target
+
+[Service]
+Type=simple
+User=hacker
+WorkingDirectory=/home/hacker/StockAnalysis
+Environment=PYTHONPATH=/home/hacker/StockAnalysis
+Environment=REDIS_URL=redis://localhost:6379
+EnvironmentFile=/home/hacker/StockAnalysis/.env
+ExecStart=/home/hacker/StockAnalysis/.venv/bin/python -m services.data_gateway.main
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+# Data gateway gets higher CPU priority (WebSocket ticks are latency-sensitive)
+CPUQuota=80%
+CPUWeight=100
+
+# Largest memory consumer — TickStore + option chains
+MemoryMax=1500M
+MemorySwapMax=512M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Merged coordinator (compact mode — orchestrator + intelligence + bot)
+
+```ini
+# /etc/systemd/system/stockanalysis-coordinator.service
+[Unit]
+Description=StockAnalysis Coordinator (Orchestrator + Intelligence + Bot)
+Requires=stockanalysis-redis.service stockanalysis-data-gateway.service
+After=stockanalysis-redis.service stockanalysis-data-gateway.service
+
+[Service]
+Type=simple
+User=hacker
+WorkingDirectory=/home/hacker/StockAnalysis
+Environment=PYTHONPATH=/home/hacker/StockAnalysis
+Environment=REDIS_URL=redis://localhost:6379
+Environment=COMPACT_MODE=1
+EnvironmentFile=/home/hacker/StockAnalysis/.env
+ExecStart=/home/hacker/StockAnalysis/.venv/bin/python -m services.coordinator.main
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+CPUQuota=60%
+CPUWeight=50
+MemoryMax=600M
+MemorySwapMax=256M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Redis (laptop-tuned)
+
+```ini
+# /etc/systemd/system/stockanalysis-redis.service
+[Unit]
+Description=StockAnalysis Redis Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/redis-server /home/hacker/StockAnalysis/configs/redis.conf
+ExecStop=/usr/bin/redis-cli shutdown
+Restart=always
+RestartSec=5
+LimitNOFILE=10032
+
+# Redis is tiny but critical — protect it
+CPUWeight=80
+MemoryMax=200M
+
+[Install]
+WantedBy=multi-user.target
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ python-dotenv==1.1.1
 python-telegram-bot==22.3
 pytz==2025.2
 PyYAML==6.0.3
+redis==5.2.1
 requests==2.32.4
 service-identity==24.2.0
 sgmllib3k==1.0.0

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+# services package

--- a/services/common/__init__.py
+++ b/services/common/__init__.py
@@ -1,0 +1,1 @@
+# Shared service infrastructure

--- a/services/common/health.py
+++ b/services/common/health.py
@@ -1,0 +1,69 @@
+"""
+Health check — each service writes a heartbeat to Redis every 10 seconds.
+
+The orchestrator and bot-service read these heartbeats for the /status dashboard.
+A service is considered "healthy" if its heartbeat is younger than 30 seconds.
+"""
+
+from __future__ import annotations
+
+import os
+import json
+import time
+import signal
+import asyncio
+import logging
+from typing import Any
+from redis.asyncio import Redis
+
+
+HEARTBEAT_INTERVAL = 10  # seconds
+HEARTBEAT_TTL = 30       # seconds — if no heartbeat in 30s, service is dead
+
+
+async def heartbeat_loop(
+    redis: Redis,
+    service_name: str,
+    get_stats: Any = None,
+    stop_event: asyncio.Event | None = None,
+    logger: logging.Logger | None = None,
+):
+    """
+    Background task: write service health to Redis every HEARTBEAT_INTERVAL seconds.
+
+    Args:
+        redis: Redis async client
+        service_name: unique name for this service (e.g., "data-gateway")
+        get_stats: optional callable returning a dict of service-specific stats
+        stop_event: when set, the loop exits
+    """
+    key = f"service:registry:{service_name}"
+    stop = stop_event or asyncio.Event()
+
+    while not stop.is_set():
+        try:
+            stats = get_stats() if callable(get_stats) else {}
+            payload = {
+                "name": service_name,
+                "pid": os.getpid(),
+                "status": "healthy",
+                "last_heartbeat": time.time(),
+                "version": "2.0.0",
+                "stats_json": json.dumps(stats, default=str),
+            }
+            await redis.hset(key, mapping=payload)
+            await redis.expire(key, HEARTBEAT_TTL + 10)
+        except Exception as e:
+            _log = logger or logging.getLogger(__name__)
+            _log.error(f"[heartbeat:{service_name}] Failed to write heartbeat: {e}")
+
+        try:
+            await asyncio.wait_for(
+                asyncio.get_event_loop().create_future() if not stop.is_set()
+                else asyncio.sleep(0),
+                timeout=HEARTBEAT_INTERVAL,
+            )
+        except asyncio.TimeoutError:
+            continue
+        except asyncio.CancelledError:
+            break

--- a/services/common/logging.py
+++ b/services/common/logging.py
@@ -1,0 +1,86 @@
+"""
+Per-service logger factory for the microservices architecture.
+
+Each service calls ``get_logger(service_name)`` to create a logger that writes to:
+- stdout (captured by systemd journal on server)
+- logs/{service_name}.log (10 MB rotating, 3 backups)
+
+The monolith (intraday_monitor.py) continues using ``common/logging_util.py``
+during the transition and is decommissioned when all services are extracted.
+
+Usage::
+
+    from services.common.logging import get_logger
+    logger = get_logger("notification-service")
+    logger.info("Sent alert for NIFTY")
+
+Output format::
+
+    14:10:23 | INFO    | SA.notification-service  | Sent alert for NIFTY
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from dotenv import load_dotenv
+
+load_dotenv()
+
+_LOG_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "logs",
+)
+os.makedirs(_LOG_DIR, exist_ok=True)
+
+# Timestamp | Level (7-char padded) | Service (20-char padded) | Message
+_LOG_FORMAT = "%(asctime)s | %(levelname)-7s | %(name)-24s | %(message)s"
+_LOG_DATE_FORMAT = "%d %H:%M:%S"
+
+# Global default — overridable per service via {SERVICE}_LOG_LEVEL env var
+_DEFAULT_LEVEL_NAME = os.environ.get("LOG_LEVEL", "INFO").upper()
+_DEFAULT_LEVEL = getattr(logging, _DEFAULT_LEVEL_NAME, logging.INFO)
+
+
+def get_logger(service_name: str) -> logging.Logger:
+    """
+    Create a service-specific logger.
+
+    Args:
+        service_name: e.g. "notification-service", "data-gateway", "analysis-engine"
+
+    Returns:
+        Configured logger with console + rotating file handlers.
+    """
+    logger = logging.getLogger(f"SA.{service_name}")
+    logger.propagate = False
+
+    # Already configured — return cached instance
+    if logger.handlers:
+        return logger
+
+    # Per-service log level override, e.g. NOTIFICATION_LOG_LEVEL=DEBUG
+    svc_level_name = os.environ.get(
+        f"{service_name.upper().replace('-', '_')}_LOG_LEVEL", ""
+    ).upper()
+    level = getattr(logging, svc_level_name, None) or _DEFAULT_LEVEL
+    logger.setLevel(level)
+
+    formatter = logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATE_FORMAT)
+
+    console = logging.StreamHandler()
+    console.setLevel(level)
+    console.setFormatter(formatter)
+    logger.addHandler(console)
+
+    file_handler = RotatingFileHandler(
+        os.path.join(_LOG_DIR, f"{service_name}.log"),
+        maxBytes=10 * 1024 * 1024,
+        backupCount=3,
+    )
+    file_handler.setLevel(level)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    return logger

--- a/services/common/redis_client.py
+++ b/services/common/redis_client.py
@@ -1,0 +1,26 @@
+"""
+Redis connection manager for all services.
+
+Provides a singleton-pattern async Redis client that reuses a single connection pool.
+Each service creates one Redis client at startup and shares it across all tasks.
+"""
+
+from __future__ import annotations
+
+import os
+from redis.asyncio import Redis as AsyncRedis
+
+
+def create_redis_client(
+    url: str | None = None,
+    decode_responses: bool = True,
+    max_connections: int = 10,
+) -> AsyncRedis:
+    redis_url = url or os.environ.get("REDIS_URL", "redis://localhost:6379")
+    return AsyncRedis.from_url(
+        redis_url,
+        decode_responses=decode_responses,
+        max_connections=max_connections,
+        retry_on_timeout=True,
+        health_check_interval=30,
+    )

--- a/services/common/redis_proxy.py
+++ b/services/common/redis_proxy.py
@@ -1,0 +1,47 @@
+"""
+RedisProxy — synchronous wrapper around Redis for use by data-gateway.
+
+In Phase 1A, the data-gateway runs synchronously (same pattern as the monolith).
+This proxy wraps the redis-py client for synchronous operations.
+In Phase 2, this will be replaced by the async redis.asyncio client.
+"""
+
+from __future__ import annotations
+
+import redis
+from typing import Any
+
+
+class RedisProxy:
+    """Synchronous Redis wrapper for data-gateway."""
+
+    def __init__(self, url: str = "redis://localhost:6379"):
+        self._client = redis.from_url(url, decode_responses=True)
+
+    def hset(self, name: str, mapping: dict) -> int:
+        return self._client.hset(name, mapping=mapping)
+
+    def hgetall(self, name: str) -> dict:
+        return self._client.hgetall(name) or {}
+
+    def hget(self, name: str, key: str) -> str | None:
+        return self._client.hget(name, key)
+
+    def set(self, name: str, value: str) -> bool:
+        return self._client.set(name, value)
+
+    def get(self, name: str) -> str | None:
+        return self._client.get(name)
+
+    def publish(self, channel: str, message: str) -> int:
+        return self._client.publish(channel, message)
+
+    def xadd(self, stream: str, fields: dict) -> str:
+        return self._client.xadd(stream, fields)
+
+    def xreadgroup(self, groupname: str, consumername: str, streams: dict,
+                   count: int | None = None, block: int | None = None) -> list | None:
+        return self._client.xreadgroup(groupname, consumername, streams, count=count, block=block)
+
+    def close(self):
+        self._client.close()

--- a/services/common/serialization.py
+++ b/services/common/serialization.py
@@ -1,0 +1,42 @@
+"""
+Serialization helpers for transmitting pandas DataFrames and nested dicts over Redis.
+
+DataFrames use pandas' built-in JSON serialization (orient='split') which is compact
+and preserves dtypes. Nested dicts use standard json.dumps with default=str for
+datetime/numpy types.
+"""
+
+from __future__ import annotations
+
+import json
+import pandas as pd
+from typing import Any
+
+
+def dataframe_to_json(df: pd.DataFrame) -> str:
+    """Serialize a DataFrame to a JSON string for Redis storage."""
+    if df is None or df.empty:
+        return "{}"
+    return df.to_json(orient="split", date_format="iso")
+
+
+def dataframe_from_json(json_str: str) -> pd.DataFrame:
+    """Deserialize a JSON string back to a DataFrame."""
+    if not json_str or json_str == "{}":
+        return pd.DataFrame()
+    return pd.read_json(json_str, orient="split")
+
+
+def safe_json_dumps(obj: Any) -> str:
+    """Serialize any Python object to JSON, handling non-serializable types."""
+    return json.dumps(obj, default=str, separators=(",", ":"))
+
+
+def safe_json_loads(json_str: str) -> Any:
+    """Deserialize a JSON string, returning None on failure."""
+    if not json_str or json_str == "{}":
+        return None
+    try:
+        return json.loads(json_str)
+    except (json.JSONDecodeError, TypeError):
+        return None

--- a/services/common/stock_proxy.py
+++ b/services/common/stock_proxy.py
@@ -1,0 +1,159 @@
+"""
+StockProxy — reconstructs Stock objects from Redis hashes and publishes Stock data to Redis.
+
+Used by:
+- data-gateway: writes fetched data to Redis (to_redis methods)
+- analysis-engine: reads data from Redis to reconstruct Stock objects (from_redis)
+- bot-service: reads specific fields for bot commands
+"""
+
+from __future__ import annotations
+
+import json
+import pandas as pd
+from redis.asyncio import Redis
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from common.Stock import Stock
+
+from services.common.serialization import (
+    dataframe_to_json,
+    dataframe_from_json,
+    safe_json_dumps,
+    safe_json_loads,
+)
+
+
+class StockProxy:
+    """Reconstructs Stock objects from Redis for analysis-engine workers."""
+
+    @staticmethod
+    async def from_redis(redis: Redis, symbol: str, is_index: bool = False) -> Stock:
+        from common.Stock import Stock
+
+        stock = Stock(symbol, symbol, is_index=is_index)
+
+        price_data = await redis.hgetall(f"data:price:{symbol}")
+        if price_data:
+            stock.priceData = dataframe_from_json(
+                price_data.get("priceData_json", "{}")
+            )
+            stock.ltp = _safe_float(price_data.get("ltp"))
+            stock.ltp_change_perc = _safe_float(price_data.get("ltp_change_perc"))
+            stock.prevDayOHLCV = safe_json_loads(
+                price_data.get("prevDayOHLCV_json", "{}")
+            )
+            stock.daily_hv = _safe_float(price_data.get("daily_hv"))
+
+        sensibull_data = await redis.hgetall(f"data:sensibull:{symbol}")
+        if sensibull_data:
+            stock.sensibull_ctx = {
+                "last_fetch_time": sensibull_data.get("last_fetch_time"),
+                "current": safe_json_loads(
+                    sensibull_data.get("current_json", "{}")
+                ) or {"underlying_info": None, "stats": None, "per_expiry_map": None, "nse_stats": None},
+                "historical_data": dataframe_from_json(
+                    sensibull_data.get("historical_data_json", "{}")
+                ),
+                "oi_chain": safe_json_loads(sensibull_data.get("oi_chain_json", "null")),
+                "oi_chain_history": safe_json_loads(
+                    sensibull_data.get("oi_chain_history_json", "[]")
+                ) or [],
+                "iv_chart_history": dataframe_from_json(
+                    sensibull_data.get("iv_chart_history_json", "{}")
+                ),
+                "oi_history": dataframe_from_json(
+                    sensibull_data.get("oi_history_json", "{}")
+                ),
+            }
+
+        zerodha_data = await redis.hgetall(f"data:zerodha:{symbol}")
+        if zerodha_data:
+            stock.zerodha_ctx = {
+                "last_notification_time": None,
+                "option_chain": {
+                    "current": dataframe_from_json(
+                        zerodha_data.get("option_chain_current_json", "{}")
+                    ),
+                    "next": None,
+                },
+                "futures_mdata": safe_json_loads(
+                    zerodha_data.get("futures_mdata_json", "{}")
+                ) or {"current": None, "next": None},
+                "futures_data": {
+                    "current": dataframe_from_json(
+                        zerodha_data.get("futures_data_current_json", "{}")
+                    ),
+                    "next": pd.DataFrame(),
+                },
+            }
+
+        return stock
+
+    @staticmethod
+    async def get_options_live(redis: Redis, symbol: str) -> dict:
+        raw = await redis.hgetall(f"data:options_live:{symbol}")
+        options_live = {}
+        for key, value in raw.items():
+            parts = key.rsplit("_", 1)
+            if len(parts) == 2:
+                strike = float(parts[0])
+                opt_type = parts[1]
+                if strike not in options_live:
+                    options_live[strike] = {}
+                options_live[strike][opt_type] = safe_json_loads(value) or {}
+        return options_live
+
+    @staticmethod
+    async def get_options_aggregate(redis: Redis, symbol: str) -> dict:
+        raw = await redis.hgetall(f"data:options_agg:{symbol}")
+        return {k: safe_json_loads(v) if isinstance(v, str) and v.startswith("{") else v
+                for k, v in raw.items()}
+
+    # ── Publish methods (used by data-gateway) ──────────────────────────
+
+    @staticmethod
+    async def publish_price_data(
+        redis: Redis, symbol: str, stock: Stock,
+    ):
+        mapping = {
+            "priceData_json": dataframe_to_json(stock.priceData),
+            "ltp": str(stock.ltp) if stock.ltp is not None else "",
+            "ltp_change_perc": str(stock.ltp_change_perc) if stock.ltp_change_perc is not None else "",
+            "prevDayOHLCV_json": safe_json_dumps(stock.prevDayOHLCV),
+            "daily_hv": str(stock.daily_hv) if stock.daily_hv is not None else "",
+        }
+        await redis.hset(f"data:price:{symbol}", mapping=mapping)
+
+    @staticmethod
+    async def publish_sensibull_data(
+        redis: Redis, symbol: str, sensibull_ctx: dict,
+    ):
+        mapping = {
+            "last_fetch_time": str(sensibull_ctx.get("last_fetch_time", "")),
+            "current_json": safe_json_dumps(sensibull_ctx.get("current", {})),
+            "historical_data_json": dataframe_to_json(
+                sensibull_ctx.get("historical_data", pd.DataFrame())
+            ),
+            "oi_chain_json": safe_json_dumps(sensibull_ctx.get("oi_chain")),
+            "oi_chain_history_json": safe_json_dumps(
+                sensibull_ctx.get("oi_chain_history", [])
+            ),
+            "iv_chart_history_json": dataframe_to_json(
+                sensibull_ctx.get("iv_chart_history", pd.DataFrame())
+            ),
+            "oi_history_json": dataframe_to_json(
+                sensibull_ctx.get("oi_history", pd.DataFrame())
+            ),
+        }
+        await redis.hset(f"data:sensibull:{symbol}", mapping=mapping)
+
+
+def _safe_float(val) -> float | None:
+    if val is None or val == "" or val == "None":
+        return None
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None

--- a/services/common/stream_consumer.py
+++ b/services/common/stream_consumer.py
@@ -1,0 +1,90 @@
+"""
+Base class for Redis Stream consumers with consumer group support.
+
+Provides:
+- Auto-creation of consumer groups (first consumer creates the group)
+- XCLAIM of stale messages from dead consumers
+- Graceful shutdown via stop_event
+- Configurable batch size and block time
+"""
+
+from __future__ import annotations
+
+import time
+import asyncio
+import json
+import logging
+from abc import ABC, abstractmethod
+from redis.asyncio import Redis
+
+
+class StreamConsumer(ABC):
+    def __init__(
+        self,
+        redis: Redis,
+        stream: str,
+        group: str,
+        consumer_name: str,
+        batch_size: int = 10,
+        block_ms: int = 5000,
+        ack_timeout: int = 120,
+        stop_event: asyncio.Event | None = None,
+        logger: logging.Logger | None = None,
+    ):
+        self.redis = redis
+        self.stream = stream
+        self.group = group
+        self.consumer = consumer_name
+        self.batch_size = batch_size
+        self.block_ms = block_ms
+        self.ack_timeout = ack_timeout
+        self.stop_event = stop_event or asyncio.Event()
+        self._running = False
+        self._log = logger or logging.getLogger(__name__)
+
+    async def start(self):
+        self._running = True
+        await self._ensure_group()
+        self._running = True
+
+        while self._running and not self.stop_event.is_set():
+            try:
+                messages = await self.redis.xreadgroup(
+                    groupname=self.group,
+                    consumername=self.consumer,
+                    streams={self.stream: ">"},
+                    count=self.batch_size,
+                    block=self.block_ms,
+                )
+                if not messages:
+                    continue
+                stream, entries = messages[0]
+                for msg_id, fields in entries:
+                    try:
+                        await self._process(msg_id, fields)
+                    except Exception as e:
+                        self._log.error(
+                            f"[{self.consumer}] Error processing {msg_id}: {e}"
+                        )
+                    finally:
+                        await self.redis.xack(self.stream, self.group, msg_id)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                self._log.error(f"[{self.consumer}] Stream error: {e}")
+                await asyncio.sleep(1)
+
+    async def stop(self):
+        self._running = False
+
+    async def _ensure_group(self):
+        try:
+            await self.redis.xgroup_create(
+                self.stream, self.group, id="0", mkstream=True
+            )
+        except Exception:
+            pass
+
+    @abstractmethod
+    async def _process(self, msg_id: str, fields: dict):
+        ...

--- a/services/data-gateway/__init__.py
+++ b/services/data-gateway/__init__.py
@@ -1,0 +1,1 @@
+# Data Gateway package

--- a/services/data-gateway/main.py
+++ b/services/data-gateway/main.py
@@ -1,0 +1,240 @@
+"""
+Data Gateway — StockAnalysis data ingestion service.
+
+Fetches data from all external sources (yfinance, Sensibull) and publishes
+to Redis. Other services (analysis-engine, orchestrator, bot) read from Redis
+instead of making direct HTTP calls.
+
+Phase 1A:
+    - yfinance historical + intraday price data → Redis HSET
+    - Sensibull insights + OI chain → Redis HSET
+
+Phase 1B:
+    - Zerodha WebSocket + REST → Redis Pub/Sub + HSET
+    - Sensibull WebSocket feed → Redis Pub/Sub
+
+Usage:
+    python -m services.data_gateway.main [--dev-intraday] [--dev-positional]
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+import json
+import signal
+import argparse
+import traceback
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from dotenv import load_dotenv
+load_dotenv()
+
+from services.common.logging import get_logger
+logger = get_logger("data-gateway")
+from common.helperFunctions import get_stock_objects_from_json
+from services.common.redis_proxy import RedisProxy
+from services.data_gateway.yfinance_fetcher import fetch_initial_daily_data, fetch_cycle_data
+from services.data_gateway.sensibull_fetcher import fetch_and_publish_cycle, INDEX_ANALYSIS_EXCLUDE
+
+
+# Configuration
+CYCLE_SLEEP = 310  # seconds between intraday cycles (same as monolith)
+DEV_LOOP_WAIT_TIME = int(os.environ.get("DEV_LOOP_WAIT_TIME", "30"))
+
+# Global state
+_running = True
+
+
+def signal_handler(signum, frame):
+    global _running
+    logger.info(f"[data-gateway] Received signal {signum}, shutting down...")
+    _running = False
+
+
+def get_symbol_lists() -> tuple[list[str], list[str], list[str], list[str]]:
+    """
+    Load stock objects from JSON and return symbol lists.
+
+    Returns:
+        tuple of (stock_symbols, index_symbols, commodity_symbols, global_indices_symbols)
+    """
+    stock_list, index_list, commodity_list, global_indices_list = get_stock_objects_from_json()
+
+    stock_symbols = [s["tradingsymbol"] for s in stock_list if s["tradingsymbol"] not in INDEX_ANALYSIS_EXCLUDE]
+    index_symbols = [i["tradingsymbol"] for i in index_list if i["tradingsymbol"] not in INDEX_ANALYSIS_EXCLUDE]
+    commodity_symbols = [c["tradingsymbol"] for c in commodity_list]
+    global_indices_symbols = [g["tradingsymbol"] for g in global_indices_list]
+
+    logger.info(f"[data-gateway] Loaded {len(stock_symbols)} stocks, {len(index_symbols)} indices, "
+                f"{len(commodity_symbols)} commodities, {len(global_indices_symbols)} global indices")
+    return stock_symbols, index_symbols, commodity_symbols, global_indices_symbols
+
+
+def get_yfinance_symbols(stock_symbols: list[str], index_symbols: list[str],
+                          commodity_symbols: list[str], global_indices_symbols: list[str],
+                          stock_list: list, index_list: list) -> tuple[list[str], list[str], list[str], list[str]]:
+    """Convert tradingsymbols to yfinance symbols."""
+    # Build lookup maps
+    stock_yf_map = {s["tradingsymbol"]: s["tradingsymbol"] + ".NS" for s in stock_list}
+    index_yf_map = {i["tradingsymbol"]: i["yfinancetradingsymbol"] for i in index_list}
+    commodity_yf_map = {c["tradingsymbol"]: c.get("yfinance_symbol", c["tradingsymbol"]) for c in commodity_list}
+    global_yf_map = {g["tradingsymbol"]: g.get("yfinance_symbol", g["tradingsymbol"]) for g in global_indices_list}
+
+    yf_stocks = [stock_yf_map.get(s) for s in stock_symbols if stock_yf_map.get(s)]
+    yf_indices = [index_yf_map.get(i) for i in index_symbols if index_yf_map.get(i)]
+    yf_commodities = [commodity_yf_map.get(c) for c in commodity_symbols if commodity_yf_map.get(c)]
+    yf_globals = [global_yf_map.get(g) for g in global_indices_symbols if global_yf_map.get(g)]
+
+    return yf_stocks, yf_indices, yf_commodities, yf_globals
+
+
+def main():
+    global _running
+
+    parser = argparse.ArgumentParser(description="StockAnalysis Data Gateway")
+    parser.add_argument("--dev-intraday", action="store_true", help="Dev intraday mode")
+    parser.add_argument("--dev-positional", action="store_true", help="Dev positional mode")
+    args = parser.parse_args()
+
+    # Register signal handlers for graceful shutdown
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
+    # Determine mode
+    is_prod = os.getenv("PRODUCTION", "0") == "1"
+    is_dev_intraday = args.dev_intraday or os.getenv("DEV_INTRADAY", "0") == "1"
+    is_dev_positional = args.dev_positional or os.getenv("DEV_POSITIONAL", "0") == "1"
+    is_intraday = is_dev_intraday or (is_prod and not is_dev_positional)
+
+    logger.info(f"[data-gateway] Starting in {'intraday' if is_intraday else 'positional'} mode")
+    logger.info(f"[data-gateway] PRODUCTION={is_prod}, DEV_INTRADAY={is_dev_intraday}, DEV_POSITIONAL={is_dev_positional}")
+
+    # Connect to Redis
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+    redis = RedisProxy(redis_url)
+    try:
+        redis.get("ping")  # Test connection
+        logger.info(f"[data-gateway] Connected to Redis at {redis_url}")
+    except Exception as e:
+        logger.error(f"[data-gateway] Cannot connect to Redis at {redis_url}: {e}")
+        sys.exit(1)
+
+    # Write initial heartbeat
+    redis.hset("service:registry:data-gateway", mapping={
+        "name": "data-gateway",
+        "pid": str(os.getpid()),
+        "status": "starting",
+        "started_at": str(time.time()),
+    })
+
+    # Load symbol lists
+    stock_symbols, index_symbols, commodity_symbols, global_indices_symbols = get_symbol_lists()
+    stock_list, index_list, commodity_list, global_indices_list = get_stock_objects_from_json()
+    yf_stocks, yf_indices, yf_commodities, yf_globals = get_yfinance_symbols(
+        stock_symbols, index_symbols, commodity_symbols, global_indices_symbols,
+        stock_list, index_list
+    )
+
+    logger.info(f"[data-gateway] yfinance symbols: {len(yf_stocks)} stocks, {len(yf_indices)} indices, "
+                f"{len(yf_commodities)} commodities, {len(yf_globals)} global indices")
+
+    # ── Initial data load ──────────────────────────────────────────────────
+    logger.info("[data-gateway] Starting initial data load...")
+    try:
+        fetch_initial_daily_data(redis, is_intraday)
+        logger.info("[data-gateway] Initial daily data loaded")
+    except Exception as e:
+        logger.error(f"[data-gateway] Initial data load failed: {e}")
+        logger.error(traceback.format_exc())
+
+    # Initial Sensibull fetch
+    try:
+        logger.info("[data-gateway] Starting initial Sensibull data fetch...")
+        fetch_and_publish_cycle(redis, stock_symbols, index_symbols,
+                                mode="intraday" if is_intraday else "positional")
+        logger.info("[data-gateway] Initial Sensibull data loaded")
+    except Exception as e:
+        logger.error(f"[data-gateway] Initial Sensibull fetch failed: {e}")
+        logger.error(traceback.format_exc())
+
+    # Mark healthy
+    redis.hset("service:registry:data-gateway", mapping={
+        "name": "data-gateway",
+        "pid": str(os.getpid()),
+        "status": "healthy",
+        "started_at": str(time.time()),
+    })
+    logger.info("[data-gateway] Initial load complete. Entering main loop.")
+
+    # ── Main loop ──────────────────────────────────────────────────────────
+    cycle_count = 0
+    while _running:
+        cycle_start = time.time()
+        cycle_count += 1
+        logger.info(f"[data-gateway] Cycle {cycle_count} starting...")
+
+        try:
+            # Step 1: Fetch yfinance price data
+            fetch_cycle_data(redis, yf_stocks, yf_indices, yf_commodities, yf_globals)
+        except Exception as e:
+            logger.error(f"[data-gateway] yfinance cycle fetch failed: {e}")
+
+        try:
+            # Step 2: Fetch Sensibull data (insights + OI chain)
+            fetch_and_publish_cycle(redis, stock_symbols, index_symbols,
+                                    mode="intraday" if is_intraday else "positional")
+        except Exception as e:
+            logger.error(f"[data-gateway] Sensibull cycle fetch failed: {e}")
+
+        # Update heartbeat
+        cycle_elapsed = time.time() - cycle_start
+        redis.hset("service:registry:data-gateway", mapping={
+            "name": "data-gateway",
+            "pid": str(os.getpid()),
+            "status": "healthy",
+            "last_heartbeat": str(time.time()),
+            "stats_json": json.dumps({
+                "cycle_count": cycle_count,
+                "cycle_elapsed": round(cycle_elapsed, 1),
+                "stocks": len(stock_symbols),
+                "indices": len(index_symbols),
+            }, default=str),
+        })
+
+        logger.info(f"[data-gateway] Cycle {cycle_count} complete in {cycle_elapsed:.1f}s")
+
+        # Sleep until next cycle
+        if _running:
+            if is_dev_intraday and not is_prod:
+                sleep_time = DEV_LOOP_WAIT_TIME
+            else:
+                # Align to next 5-min bar (same logic as monolith)
+                now = time.localtime()
+                seconds_elapsed = now.tm_sec + (now.tm_min % 5) * 60
+                sleep_time = CYCLE_SLEEP - seconds_elapsed
+                if sleep_time <= 0:
+                    sleep_time = CYCLE_SLEEP
+
+            logger.debug(f"[data-gateway] Sleeping {sleep_time}s until next cycle")
+            # Sleep in 1s chunks so SIGTERM is responsive
+            for _ in range(int(sleep_time)):
+                if not _running:
+                    break
+                time.sleep(1)
+
+    # Clean shutdown
+    logger.info("[data-gateway] Shutting down...")
+    redis.hset("service:registry:data-gateway", mapping={
+        "name": "data-gateway",
+        "pid": str(os.getpid()),
+        "status": "shutdown",
+    })
+    redis.close()
+    logger.info("[data-gateway] Shutdown complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/data-gateway/sensibull_fetcher.py
+++ b/services/data-gateway/sensibull_fetcher.py
@@ -1,0 +1,317 @@
+"""
+Sensibull data fetcher — fetches Sensibull insights + OI chain and publishes to Redis.
+
+Ported from fno/sensibull_fetcher.py but publishes results to Redis hashes
+instead of writing to Stock.sensibull_ctx directly.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import time
+from urllib.parse import quote
+
+import requests
+import pandas as pd
+
+from services.common.logging import get_logger
+logger = get_logger("data-gateway")
+from services.common.stock_proxy import StockProxy
+
+
+SENSIBULL_BASE = "https://oxide.sensibull.com/v1/compute"
+INDEX_ANALYSIS_EXCLUDE = {"INDIA_VIX", "FINNIFTY"}
+
+
+def fetch_sensibull_data(symbol: str, mode: str = "intraday") -> dict | None:
+    """
+    Fetch Sensibull insights for a single symbol.
+
+    Returns:
+        dict with keys: underlying_info, stats, per_expiry_map, nse_stats,
+        historical_row (for building historical_data)
+    """
+    try:
+        encoded = quote(symbol, safe="")
+        url = f"{SENSIBULL_BASE}/cache/insights/stock_info?tradingsymbol={encoded}"
+        response = requests.get(url, timeout=(5, 10))
+        response.raise_for_status()
+        data = response.json()
+
+        if not (data.get("success") and "payload" in data):
+            logger.warning(f"[Sensibull] Unsuccessful response for {symbol}")
+            return None
+
+        payload = data["payload"]
+        stats = payload.get("stats", {})
+        base_stats = stats.get("underlying_base_stats", {})
+        per_expiry_map = stats.get("per_expiry_map", {})
+
+        result = {
+            "underlying_info": payload.get("underlying_info"),
+            "stats": stats,
+            "per_expiry_map": per_expiry_map,
+            "nse_stats": payload.get("nse_stats"),
+        }
+
+        return result
+
+    except requests.exceptions.Timeout:
+        logger.error(f"[Sensibull] Timeout fetching data for {symbol}")
+    except requests.exceptions.RequestException as e:
+        logger.error(f"[Sensibull] Request error for {symbol}: {e}")
+    except Exception as e:
+        logger.error(f"[Sensibull] Error for {symbol}: {e}")
+    return None
+
+
+def fetch_sensibull_oi_chain(symbol: str, per_expiry_map: dict, mode: str = "intraday") -> dict | None:
+    """
+    Fetch Sensibull OI chain for a single symbol.
+
+    Args:
+        symbol: stock/index symbol
+        per_expiry_map: from fetch_sensibull_data() output
+        mode: "intraday" or "positional"
+
+    Returns:
+        OI chain dict with per_strike_data
+    """
+    try:
+        sorted_expiries = sorted(per_expiry_map.keys())
+        if not sorted_expiries:
+            logger.warning(f"[Sensibull] No expiry data for {symbol}, skipping OI chain")
+            return None
+
+        nearest = sorted_expiries[0]
+        expiries_body = {
+            exp: {"is_weekly": False, "is_enabled": exp == nearest}
+            for exp in sorted_expiries
+        }
+
+        body = {
+            "underlying": symbol,
+            "expiries": expiries_body,
+            "atm_strike_selection": "twenty",
+            "input_min_strike": None,
+            "input_max_strike": None,
+            "auto_update": "full_day",
+            "show_prev_oi": True,
+        }
+
+        url = f"{SENSIBULL_BASE}/1/oi_graphs/oi_chart"
+        response = requests.post(url, json=body, timeout=(5, 15))
+        response.raise_for_status()
+        data = response.json()
+
+        if not (data.get("success") and "payload" in data):
+            logger.warning(f"[Sensibull] OI chain unsuccessful for {symbol}")
+            return None
+
+        payload = data["payload"]
+        timestamp = datetime.datetime.now()
+
+        enabled_expiry = None
+        for exp_date, exp_info in payload.get("input", {}).get("expiries", {}).items():
+            if exp_info.get("is_enabled", False):
+                enabled_expiry = exp_date
+                break
+
+        oi_chain = {
+            "timestamp": timestamp.isoformat(),
+            "date": payload.get("input", {}).get("date", timestamp.strftime("%Y-%m-%d")),
+            "expiry": enabled_expiry,
+            "underlying_symbol": symbol,
+            "prev_ltp": payload.get("prev_ltp"),
+            "current_ltp": payload.get("current_ltp") or payload.get("date_ltp"),
+            "date_ltp": payload.get("date_ltp"),
+            "atm_strike": payload.get("atm_strike"),
+            "total_call_oi": payload.get("total_call_oi", 0),
+            "total_put_oi": payload.get("total_put_oi", 0),
+            "total_call_oi_change": payload.get("total_call_oi_change", 0),
+            "total_put_oi_change": payload.get("total_put_oi_change", 0),
+            "pcr": payload.get("pcr"),
+            "per_strike_data": payload.get("per_strike_data", {}),
+            "strike_list": payload.get("strike_list", []),
+            "min_strike": payload.get("min_strike"),
+            "max_strike": payload.get("max_strike"),
+            "underlying_token": payload.get("underlying_token"),
+        }
+
+        return oi_chain
+
+    except requests.exceptions.Timeout:
+        logger.error(f"[Sensibull] Timeout fetching OI chain for {symbol}")
+    except requests.exceptions.RequestException as e:
+        logger.error(f"[Sensibull] Request error for OI chain {symbol}: {e}")
+    except Exception as e:
+        logger.error(f"[Sensibull] Error fetching OI chain for {symbol}: {e}")
+    return None
+
+
+def build_historical_row(symbol: str, sensibull_data: dict) -> dict:
+    """Build a single historical_data row from the Sensibull insights payload."""
+    stats = sensibull_data.get("stats", {})
+    base_stats = stats.get("underlying_base_stats", {})
+    per_expiry_map = stats.get("per_expiry_map", {})
+
+    row = {
+        "timestamp": datetime.datetime.now(),
+        "volume_spike": base_stats.get("volume_spike"),
+        "volume_spike_type": base_stats.get("volume_spike_type"),
+        "future_oi_change": base_stats.get("future_oi_change"),
+        "oi_change_type": base_stats.get("oi_change_type"),
+        "total_pcr": base_stats.get("total_pcr"),
+    }
+
+    for expiry, expiry_data in per_expiry_map.items():
+        sfx = expiry.replace("-", "")
+        row[f"future_price_{sfx}"] = expiry_data.get("future_price")
+        row[f"future_change_pct_{sfx}"] = expiry_data.get("future_change_percent")
+        row[f"atm_strike_{sfx}"] = expiry_data.get("atm_strike")
+        row[f"atm_iv_{sfx}"] = expiry_data.get("atm_iv")
+        row[f"atm_iv_change_{sfx}"] = expiry_data.get("atm_iv_change")
+        row[f"atm_iv_percentile_{sfx}"] = expiry_data.get("atm_iv_percentile")
+        row[f"atm_ivp_type_{sfx}"] = expiry_data.get("atm_ivp_type")
+        row[f"max_pain_{sfx}"] = expiry_data.get("max_pain_strike")
+        row[f"max_pain_type_{sfx}"] = expiry_data.get("max_pain_type")
+        row[f"pcr_{sfx}"] = expiry_data.get("pcr")
+        row[f"pcr_type_{sfx}"] = expiry_data.get("pcr_type")
+        row[f"lot_size_{sfx}"] = expiry_data.get("lot_size")
+
+    return row
+
+
+def publish_to_redis(redis_proxy, symbol: str, current_data: dict | None,
+                     oi_chain: dict | None, existing_ctx: dict | None, mode: str = "intraday"):
+    """
+    Publish Sensibull data to Redis hashes.
+
+    Args:
+        redis_proxy: RedisProxy instance
+        symbol: stock/index symbol
+        current_data: sensibull insights result dict (or None)
+        oi_chain: OI chain result dict (or None)
+        existing_ctx: existing sensibull_ctx from Redis (or empty dict)
+        mode: "intraday" or "positional"
+    """
+    ctx = existing_ctx or {}
+    if current_data:
+        ctx["current"] = current_data
+        ctx["last_fetch_time"] = str(datetime.datetime.now())
+
+        # Build and append historical row
+        new_row = build_historical_row(symbol, current_data)
+        new_row_df = pd.DataFrame([new_row])
+
+        existing_hist = ctx.get("historical_data", pd.DataFrame())
+        if isinstance(existing_hist, str):
+            existing_hist = pd.DataFrame()
+
+        if not existing_hist.empty:
+            updated_hist = pd.concat([existing_hist, new_row_df], ignore_index=True)
+            if mode == "positional":
+                ctx["historical_data"] = updated_hist.tail(30)
+            else:
+                five_days_ago = datetime.datetime.now() - datetime.timedelta(days=5)
+                ctx["historical_data"] = updated_hist[updated_hist["timestamp"] >= five_days_ago]
+        else:
+            ctx["historical_data"] = new_row_df
+
+    if oi_chain:
+        ctx["oi_chain"] = oi_chain
+        history = ctx.get("oi_chain_history", [])
+        history.append(oi_chain)
+        if len(history) > 15:
+            history = history[-15:]
+        ctx["oi_chain_history"] = history
+
+    # Serialize to Redis
+    mapping = {
+        "last_fetch_time": str(ctx.get("last_fetch_time", "")),
+        "current_json": json.dumps(ctx.get("current", {}), default=str),
+        "historical_data_json": ctx.get("historical_data", pd.DataFrame()).to_json(orient="split", date_format="iso") if isinstance(ctx.get("historical_data"), pd.DataFrame) else "{}",
+        "oi_chain_json": json.dumps(ctx.get("oi_chain"), default=str) if ctx.get("oi_chain") else "null",
+        "oi_chain_history_json": json.dumps(ctx.get("oi_chain_history", []), default=str),
+        "iv_chart_history_json": ctx.get("iv_chart_history", pd.DataFrame()).to_json(orient="split", date_format="iso") if isinstance(ctx.get("iv_chart_history"), pd.DataFrame) else "{}",
+        "oi_history_json": ctx.get("oi_history", pd.DataFrame()).to_json(orient="split", date_format="iso") if isinstance(ctx.get("oi_history"), pd.DataFrame) else "{}",
+    }
+
+    redis_proxy.hset(f"data:sensibull:{symbol}", mapping=mapping)
+    logger.info(f"[Sensibull] Published data for {symbol} (current: {current_data is not None}, oi_chain: {oi_chain is not None})")
+
+
+def fetch_and_publish_cycle(redis_proxy, stock_symbols: list[str], index_symbols: list[str],
+                            mode: str = "intraday"):
+    """
+    Fetch Sensibull data + OI chain for all symbols in a single cycle.
+    Runs sequentially per symbol to avoid overwhelming the free API.
+
+    Args:
+        redis_proxy: RedisProxy instance
+        stock_symbols: list of stock symbols (e.g. ["RELIANCE", "TCS"])
+        index_symbols: list of index symbols (e.g. ["NIFTY", "BANKNIFTY"])
+        mode: "intraday" or "positional"
+    """
+    all_symbols = stock_symbols + index_symbols
+    successes = 0
+    failures = 0
+
+    for symbol in all_symbols:
+        if symbol in INDEX_ANALYSIS_EXCLUDE:
+            continue
+
+        try:
+            # Fetch existing ctx from Redis
+            existing_raw = redis_proxy.hgetall(f"data:sensibull:{symbol}")
+            existing_ctx = _deserialize_sensibull_ctx(existing_raw)
+
+            # Step 1: Fetch insights
+            current_data = fetch_sensibull_data(symbol, mode)
+            if current_data is None:
+                failures += 1
+                continue
+
+            per_expiry_map = current_data.get("per_expiry_map", {})
+
+            # Step 2: Fetch OI chain
+            oi_chain = fetch_sensibull_oi_chain(symbol, per_expiry_map, mode)
+
+            # Step 3: Publish to Redis
+            publish_to_redis(redis_proxy, symbol, current_data, oi_chain, existing_ctx, mode)
+            successes += 1
+
+        except Exception as e:
+            logger.error(f"[Sensibull] Error in cycle for {symbol}: {e}")
+            failures += 1
+
+    logger.info(f"[Sensibull] Cycle complete: {successes} success, {failures} failure")
+
+
+def _deserialize_sensibull_ctx(raw: dict) -> dict:
+    """Convert raw Redis hgetall result back to a sensibull_ctx dict."""
+    ctx = {}
+    if not raw:
+        return ctx
+
+    current_json = raw.get("current_json", "{}")
+    ctx["current"] = json.loads(current_json) if current_json != "{}" else {}
+    ctx["last_fetch_time"] = raw.get("last_fetch_time")
+
+    hist_json = raw.get("historical_data_json", "{}")
+    ctx["historical_data"] = pd.read_json(hist_json, orient="split") if hist_json != "{}" else pd.DataFrame()
+
+    oi_chain_raw = raw.get("oi_chain_json", "null")
+    ctx["oi_chain"] = json.loads(oi_chain_raw) if oi_chain_raw != "null" else None
+
+    hist_list_raw = raw.get("oi_chain_history_json", "[]")
+    ctx["oi_chain_history"] = json.loads(hist_list_raw) if hist_list_raw != "[]" else []
+
+    iv_chart_raw = raw.get("iv_chart_history_json", "{}")
+    ctx["iv_chart_history"] = pd.read_json(iv_chart_raw, orient="split") if iv_chart_raw != "{}" else pd.DataFrame()
+
+    oi_hist_raw = raw.get("oi_history_json", "{}")
+    ctx["oi_history"] = pd.read_json(oi_hist_raw, orient="split") if oi_hist_raw != "{}" else pd.DataFrame()
+
+    return ctx

--- a/services/data-gateway/yfinance_fetcher.py
+++ b/services/data-gateway/yfinance_fetcher.py
@@ -1,0 +1,233 @@
+"""
+yfinance fetcher — downloads price data for all tracked symbols and publishes to Redis.
+
+Replicates the logic from intraday/intraday_monitor.py:fetch_price_data()
+and create_stock_and_index_objects(), but publishes results to Redis
+instead of writing directly to Stock objects.
+"""
+
+from __future__ import annotations
+
+import time
+import logging
+import yfinance as yf
+import pandas as pd
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from services.common.redis_proxy import RedisProxy
+
+from services.common.logging import get_logger
+logger = get_logger("data-gateway")
+from common.helperFunctions import get_stock_objects_from_json
+from services.common.stock_proxy import StockProxy
+
+
+def fetch_initial_daily_data(redis_proxy: "RedisProxy", is_intraday: bool):
+    """
+    Fetch prev-day OHLCV + daily price data for all symbols.
+    Called once at data-gateway startup.
+
+    Publishes:
+        - data:price:{symbol} → prevDayOHLCV_json, daily_hv, priceData_json (daily data)
+    """
+    stock_list, index_list, commodity_list, global_indices_list = get_stock_objects_from_json()
+
+    _fetch_index_initial(redis_proxy, index_list, is_intraday)
+    _fetch_stock_initial(redis_proxy, stock_list, is_intraday)
+
+
+def _fetch_index_initial(redis_proxy, index_list, is_intraday):
+    symbols = [idx["yfinancetradingsymbol"] for idx in index_list]
+    if not symbols:
+        return
+
+    period = "1y" if is_intraday else "5D"
+    logger.info(f"[yfinance] Fetching initial daily data for {len(symbols)} indices ({period})")
+
+    try:
+        data = yf.download(symbols, period=period, interval="1d", group_by="ticker", auto_adjust=True, progress=False)
+        for idx in index_list:
+            symbol = idx["yfinancetradingsymbol"]
+            name = idx["tradingsymbol"]
+            try:
+                if len(symbols) == 1:
+                    idx_data = data
+                else:
+                    idx_data = data[symbol]
+
+                if idx_data.empty or len(idx_data) < 2:
+                    logger.warning(f"[yfinance] Insufficient data for {name} ({symbol}), skipping")
+                    continue
+
+                ohlcv_row = idx_data.iloc[-2]
+                prev_day = {
+                    "OPEN": float(ohlcv_row["Open"]),
+                    "HIGH": float(ohlcv_row["High"]),
+                    "LOW": float(ohlcv_row["Low"]),
+                    "CLOSE": float(ohlcv_row["Close"]),
+                    "VOLUME": float(ohlcv_row["Volume"]),
+                }
+
+                idx_data.index = idx_data.index.tz_localize("UTC").tz_convert("Asia/Kolkata") if idx_data.index.tz is None else idx_data.index.tz_convert("Asia/Kolkata")
+                idx_data = idx_data.dropna(how="all")
+
+                import numpy as np
+                returns = idx_data["Close"].pct_change().dropna()
+                daily_hv = float(returns.std() * (252 ** 0.5) * 100) if len(returns) > 1 else None
+
+                mapping = {
+                    "priceData_json": idx_data.to_json(orient="split", date_format="iso"),
+                    "prevDayOHLCV_json": __import__("json").dumps(prev_day, default=str),
+                    "ltp": "",
+                    "ltp_change_perc": "",
+                    "daily_hv": str(daily_hv) if daily_hv else "",
+                }
+                redis_proxy.hset(f"data:price:{name}", mapping=mapping)
+                logger.info(f"[yfinance] Published initial data for index {name} ({len(idx_data)} rows)")
+
+            except (KeyError, IndexError) as e:
+                logger.warning(f"[yfinance] Failed to get initial data for {name}: {e}")
+    except Exception as e:
+        logger.error(f"[yfinance] Error fetching initial index data: {e}")
+
+
+def _fetch_stock_initial(redis_proxy, stock_list, is_intraday):
+    symbols = [stk["tradingsymbol"] + ".NS" for stk in stock_list]
+    if not symbols:
+        return
+
+    period = "1y" if is_intraday else "5D"
+    logger.info(f"[yfinance] Fetching initial daily data for {len(symbols)} stocks ({period})")
+
+    try:
+        data = yf.download(symbols, period=period, interval="1d", group_by="ticker", auto_adjust=True, progress=False)
+        for stk in stock_list:
+            symbol = stk["tradingsymbol"] + ".NS"
+            name = stk["tradingsymbol"]
+            try:
+                if len(symbols) == 1:
+                    stk_data = data
+                else:
+                    stk_data = data[symbol]
+
+                if stk_data.empty or len(stk_data) < 2:
+                    logger.warning(f"[yfinance] Insufficient data for {name}, skipping")
+                    continue
+
+                ohlcv_row = stk_data.iloc[-2]
+                prev_day = {
+                    "OPEN": float(ohlcv_row["Open"]),
+                    "HIGH": float(ohlcv_row["High"]),
+                    "LOW": float(ohlcv_row["Low"]),
+                    "CLOSE": float(ohlcv_row["Close"]),
+                    "VOLUME": float(ohlcv_row["Volume"]),
+                }
+
+                stk_data.index = stk_data.index.tz_localize("UTC").tz_convert("Asia/Kolkata") if stk_data.index.tz is None else stk_data.index.tz_convert("Asia/Kolkata")
+                stk_data = stk_data.dropna(how="all")
+
+                returns = stk_data["Close"].pct_change().dropna()
+                daily_hv = float(returns.std() * (252 ** 0.5) * 100) if len(returns) > 1 else None
+
+                mapping = {
+                    "priceData_json": stk_data.to_json(orient="split", date_format="iso"),
+                    "prevDayOHLCV_json": __import__("json").dumps(prev_day, default=str),
+                    "ltp": "",
+                    "ltp_change_perc": "",
+                    "daily_hv": str(daily_hv) if daily_hv else "",
+                }
+                redis_proxy.hset(f"data:price:{name}", mapping=mapping)
+                logger.info(f"[yfinance] Published initial data for stock {name} ({len(stk_data)} rows)")
+
+            except (KeyError, IndexError) as e:
+                logger.warning(f"[yfinance] Failed to get initial data for {name}: {e}")
+    except Exception as e:
+        logger.error(f"[yfinance] Error fetching initial stock data: {e}")
+
+
+def fetch_cycle_data(redis_proxy: "RedisProxy", stock_symbols: list[str], index_symbols: list[str],
+                     commodity_symbols: list[str] = None, global_indices_symbols: list[str] = None):
+    """
+    Fetch intraday 5-min or positional daily data for the current cycle.
+    Publishes updated priceData to Redis.
+
+    Args:
+        stock_symbols: list of yfinance symbols for F&O stocks
+        index_symbols: list of yfinance symbols for indices
+        commodity_symbols: list of yfinance symbols for commodities
+        global_indices_symbols: list of yfinance symbols for global indices
+    """
+    import os
+    from dotenv import load_dotenv
+    load_dotenv()
+
+    is_prod = os.getenv("PRODUCTION", "0") == "1"
+    is_dev_intraday = os.getenv("DEV_INTRADAY", "0") == "1"
+    is_dev_positional = os.getenv("DEV_POSITIONAL", "0") == "1"
+
+    is_positional = is_dev_positional or (is_prod and not is_dev_intraday)
+    period = "2y" if is_positional else "5d"
+    interval = "1d" if is_positional else "5m"
+
+    t0 = time.time()
+
+    if stock_symbols:
+        _download_group(redis_proxy, stock_symbols, period, interval, "stock")
+    if index_symbols:
+        _download_group(redis_proxy, index_symbols, period, interval, "index")
+    if commodity_symbols:
+        _download_group(redis_proxy, commodity_symbols, period, interval, "commodity")
+    if global_indices_symbols:
+        _download_group(redis_proxy, global_indices_symbols, period, interval, "global_index")
+
+    elapsed = time.time() - t0
+    logger.info(f"[yfinance] Cycle fetch complete: {elapsed:.1f}s ({len(stock_symbols)} stocks, {len(index_symbols)} indices)")
+
+
+def _download_group(redis_proxy, symbols: list[str], period: str, interval: str, group_name: str):
+    if not symbols:
+        return
+
+    try:
+        data = yf.download(symbols, period=period, interval=interval, group_by="ticker", auto_adjust=True, progress=False)
+
+        for symbol in symbols:
+            try:
+                if len(symbols) == 1:
+                    sym_data = data
+                else:
+                    sym_data = data[symbol]
+            except KeyError:
+                logger.warning(f"[yfinance] {symbol} not found in yfinance download ({group_name})")
+                continue
+
+            if sym_data.empty:
+                continue
+
+            # Convert timezone
+            try:
+                if sym_data.index.tz is None:
+                    sym_data.index = sym_data.index.tz_localize("UTC").tz_convert("Asia/Kolkata")
+                else:
+                    sym_data.index = sym_data.index.tz_convert("Asia/Kolkata")
+            except Exception:
+                pass
+
+            sym_data = sym_data.dropna(how="all")
+            expected = {"Open", "High", "Low", "Close", "Volume"}
+            actual = set(sym_data.columns.tolist())
+            if not expected.issubset(actual):
+                logger.warning(f"[yfinance] {symbol}: unexpected columns {sym_data.columns.tolist()}")
+                continue
+
+            # Derive stock symbol key from yfinance symbol (strip .NS)
+            stock_key = symbol.replace(".NS", "")
+            mapping = {
+                "priceData_json": sym_data.to_json(orient="split", date_format="iso"),
+                "last_price_update": str(pd.Timestamp.now(tz="Asia/Kolkata")),
+            }
+            redis_proxy.hset(f"data:price:{stock_key}", mapping=mapping)
+
+    except Exception as e:
+        logger.error(f"[yfinance] Error fetching {group_name} data: {e}")

--- a/services/notification-service/__init__.py
+++ b/services/notification-service/__init__.py
@@ -1,0 +1,1 @@
+# Notification Service package

--- a/services/notification-service/main.py
+++ b/services/notification-service/main.py
@@ -1,0 +1,287 @@
+"""
+Notification Service — consumes notification jobs from Redis and sends them
+to Telegram / Discord with retry logic.
+
+Reads from stream: notification:jobs
+Uses consumer group: notifier
+
+Message format:
+    {
+        "chat_type": "intraday" | "positional" | "live_options",
+        "message": "formatted HTML text",
+        "parse_mode": "HTML" | None,
+        "message_type": "analysis_result" | "startup" | "shutdown" | "report" | "crash" | "stale_data",
+        "symbol": "RELIANCE" | None,         # optional, for logging
+        "priority": "HIGH" | "CRITICAL" | None,
+        "timestamp": "2026-06-27T12:00:00",
+    }
+
+On failure: dead-letter to notification:dead after 3 retries.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import json
+import time
+import signal
+import argparse
+import traceback
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from dotenv import load_dotenv
+load_dotenv()
+
+import redis as sync_redis
+from services.common.logging import get_logger
+logger = get_logger("notification-service")
+from common.constants import (
+    TELEGRAM_INTRADAY_CHAT_ID, TELEGRAM_INTRADAY_TOKEN,
+    TELEGRAM_POSITIONAL_CHAT_ID, TELEGRAM_POSITIONAL_TOKEN,
+    TELEGRAM_LIVE_OPTIONS_TOKEN, TELEGRAM_LIVE_OPTIONS_CHAT_ID,
+    TELEGRAM_URL,
+    NOTIFICATION_CHANNEL,
+    DISCORD_INTRADAY_WEBHOOK_URL,
+    DISCORD_POSITIONAL_WEBHOOK_URL,
+    DISCORD_LIVE_OPTIONS_WEBHOOK_URL,
+    ENV_PRODUCTION,
+)
+import requests
+import re
+
+_running = True
+
+
+def signal_handler(signum, frame):
+    global _running
+    logger.info("[notification-service] Received signal, shutting down...")
+    _running = False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Discord helpers (ported from notification/Notification.py)
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _html_to_discord(text: str) -> str:
+    text = re.sub(r"<b>(.*?)</b>", r"**\1**", text, flags=re.DOTALL)
+    text = re.sub(r"<i>(.*?)</i>", r"*\1*", text, flags=re.DOTALL)
+    text = re.sub(r"<code>(.*?)</code>", r"`\1`", text, flags=re.DOTALL)
+    text = re.sub(r"<pre>(.*?)</pre>", r"```\1```", text, flags=re.DOTALL)
+    text = re.sub(r"<[^>]+>", "", text)
+    return text
+
+
+def _send_discord(webhook_url: str, message: str, parse_mode: str | None = None) -> bool:
+    if not webhook_url:
+        return False
+    content = _html_to_discord(message) if parse_mode and parse_mode.upper() == "HTML" else message
+    if len(content) > 2000:
+        content = content[:1997] + "..."
+    try:
+        resp = requests.post(
+            webhook_url,
+            json={"content": content},
+            timeout=(5, 10),
+        )
+        if resp.status_code not in (200, 204):
+            logger.error(f"Discord webhook failed: {resp.status_code}: {resp.text}")
+            return False
+        return True
+    except Exception as e:
+        logger.error(f"Discord webhook error: {e}")
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Telegram sender (ports TELEGRAM_NOTIFICATIONS.send_notification)
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _send_telegram(token: str, chat_id: str, message: str, parse_mode: str | None = None) -> bool:
+    """Send a single Telegram message with 3x retry + exponential backoff."""
+    if not token or not chat_id:
+        logger.debug(f"[notification] Telegram token/chat_id not configured")
+        return False
+
+    payload = {"chat_id": chat_id, "text": message}
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+
+    for attempt in range(1, 4):
+        try:
+            resp = requests.post(
+                TELEGRAM_URL + token + "/sendMessage",
+                json=payload,
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                return True
+            logger.error(
+                f"[notification] Telegram send failed (attempt {attempt}): "
+                f"status={resp.status_code}: {resp.text[:200]}"
+            )
+            if attempt < 3:
+                time.sleep(2 ** attempt)
+        except requests.Timeout:
+            logger.error(f"[notification] Telegram timeout (attempt {attempt})")
+            if attempt < 3:
+                time.sleep(2 ** attempt)
+        except requests.ConnectionError:
+            logger.error(f"[notification] Telegram connection error (attempt {attempt})")
+            if attempt < 3:
+                time.sleep(2 ** attempt)
+        except Exception as e:
+            logger.error(f"[notification] Telegram send failed: {e}")
+            return False
+
+    return False  # all retries exhausted
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Notification router
+# ═══════════════════════════════════════════════════════════════════════════
+
+def dispatch_notification(job: dict) -> bool:
+    """
+    Route a notification job to the correct channel(s).
+
+    Args:
+        job: dict with keys: chat_type, message, parse_mode (optional)
+
+    Returns:
+        True if sent successfully to at least one channel
+    """
+    chat_type = job.get("chat_type", "intraday")
+    message = job.get("message", "")
+    parse_mode = job.get("parse_mode")
+
+    channel = NOTIFICATION_CHANNEL.lower()
+    sent_any = False
+
+    if channel in ("discord", "both"):
+        webhook_map = {
+            "intraday": DISCORD_INTRADAY_WEBHOOK_URL,
+            "positional": DISCORD_POSITIONAL_WEBHOOK_URL,
+            "live_options": DISCORD_LIVE_OPTIONS_WEBHOOK_URL,
+        }
+        webhook = webhook_map.get(chat_type)
+        if _send_discord(webhook, message, parse_mode):
+            sent_any = True
+
+    if channel in ("telegram", "both"):
+        token_map = {
+            "intraday": (TELEGRAM_INTRADAY_TOKEN, TELEGRAM_INTRADAY_CHAT_ID),
+            "positional": (TELEGRAM_POSITIONAL_TOKEN, TELEGRAM_POSITIONAL_CHAT_ID),
+            "live_options": (TELEGRAM_LIVE_OPTIONS_TOKEN, TELEGRAM_LIVE_OPTIONS_CHAT_ID),
+        }
+        token, chat_id = token_map.get(chat_type, ("", ""))
+        if _send_telegram(token, chat_id, message, parse_mode):
+            sent_any = True
+
+    return sent_any
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Dead letter
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _send_to_dead_letter(redis_client, original: dict, error: str):
+    """Write a failed notification to the dead letter stream for manual inspection."""
+    try:
+        redis_client.xadd("notification:dead", {
+            "original": json.dumps(original, default=str),
+            "error": error,
+            "timestamp": str(time.time()),
+        })
+        logger.warning(f"[notification] Dead-lettered: {original.get('message_type', 'unknown')} — {error}")
+    except Exception as e:
+        logger.error(f"[notification] Failed to write dead letter: {e}")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Main loop
+# ═══════════════════════════════════════════════════════════════════════════
+
+def main():
+    global _running
+
+    parser = argparse.ArgumentParser(description="StockAnalysis Notification Service")
+    parser.add_argument("--consumer-name", default="notifier-1", help="Consumer name for this instance")
+    args = parser.parse_args()
+
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+    rc = sync_redis.from_url(redis_url, decode_responses=True)
+    consumer_name = args.consumer_name
+
+    logger.info(f"[notification-service] Starting (consumer={consumer_name}, redis={redis_url})")
+
+    # Ensure consumer group exists
+    try:
+        rc.xgroup_create("notification:jobs", "notifier", id="0", mkstream=True)
+    except Exception:
+        pass  # already exists
+
+    # Heartbeat
+    rc.hset("service:registry:notification-service", mapping={
+        "name": "notification-service",
+        "pid": str(os.getpid()),
+        "status": "healthy",
+        "consumer": consumer_name,
+    })
+
+    _running = True
+    retry_count = 0
+
+    while _running:
+        try:
+            messages = rc.xreadgroup(
+                groupname="notifier",
+                consumername=consumer_name,
+                streams={"notification:jobs": ">"},
+                count=10,
+                block=2000,
+            )
+        except Exception as e:
+            logger.error(f"[notification-service] Redis error: {e}")
+            retry_count += 1
+            time.sleep(min(retry_count * 2, 30))
+            continue
+
+        retry_count = 0  # reset on successful read
+
+        if not messages:
+            continue
+
+        entries = messages[0][1] if isinstance(messages, list) and messages else []
+        for msg_id, fields in entries:
+            try:
+                job = dict(fields)
+                success = dispatch_notification(job)
+                if not success:
+                    error = f"Failed to send after 3 retries"
+                    _send_to_dead_letter(rc, job, error)
+                else:
+                    logger.info(
+                        f"[notification] Sent: {job.get('message_type', 'unknown')} "
+                        f"→ {job.get('chat_type', 'unknown')}"
+                    )
+            except Exception as e:
+                _send_to_dead_letter(rc, dict(fields), str(e))
+                logger.error(f"[notification] Error processing job {msg_id}: {e}")
+            finally:
+                try:
+                    rc.xack("notification:jobs", "notifier", msg_id)
+                except Exception:
+                    pass
+
+    # Shutdown
+    logger.info("[notification-service] Shutting down...")
+    rc.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/zerodha/zerodha_analysis.py
+++ b/zerodha/zerodha_analysis.py
@@ -30,7 +30,7 @@ class ZerodhaTickerManager:
         self._kt: KiteTicker | None = None
         self.max_retries = 50
         self.retry_delay = 5  # seconds
-        self.tick_queue = queue.Queue(maxsize=2000)
+        self.tick_queue = queue.Queue(maxsize=5000)
         self.processor_thread = None
         self.stop_processor = False
         self.notification_cooldown = 300  # 5 minutes cooldown
@@ -570,7 +570,10 @@ class ZerodhaTickerManager:
             try:
                 self.tick_queue.put_nowait(tick)
             except queue.Full:
-                logger.warning(f"[ZerodhaWS] tick_queue full (maxsize=2000) — dropping tick for token {tick.get('instrument_token')}")
+                token = tick.get("instrument_token")
+                info = self.token_registry.lookup(token) if self.token_registry else None
+                symbol = info.parent_symbol if info else "unknown"
+                logger.warning(f"[ZerodhaWS] tick_queue full (maxsize=5000) — dropping tick for token {token} ({symbol})")
 
     def on_reconnect(self, ws, attempts_count):
         self.reconnect_attempts = attempts_count


### PR DESCRIPTION
## Summary

Extract the notification system as the first microservice. All notifications now route through Redis by default, with direct HTTP as fallback.

## Changes

### Notification Service (New)
- `services/notification-service/main.py` — Redis Stream consumer reading from `notification:jobs` (consumer group: `notifier`)
- Handles Telegram + Discord dispatch with 3× retry + exponential backoff
- Dead-letter stream for failed notifications
- No feature flags — Redis is the primary path, HTTP is fallback

### Notification Routing (`notification/Notification.py`)
- `send_notification()` now writes to Redis stream by default
- Falls back to direct HTTP only when Redis is unavailable
- `send_live_options_notification()` follows the same pattern
- Zero call-site changes in the monolith

### Per-Service Logging (`services/common/logging.py`)
- New `get_logger(service_name)` factory function
- Each service writes to its own file: `logs/{service-name}.log` (10 MB rotating, 3 backups)
- Per-service log level via `{SERVICE}_LOG_LEVEL` env var
- Console output for systemd journal capture on server

### Shared Infrastructure (`services/common/`)
- `redis_client.py` — Async Redis connection manager
- `redis_proxy.py` — Sync Redis wrapper for synchronous services
- `serialization.py` — DataFrame/dict JSON serialization
- `health.py` — Service heartbeat loop (writes to `service:registry:*`)
- `stock_proxy.py` — Stock object ↔ Redis serialization
- `stream_consumer.py` — Base class for Redis Stream consumers
- `logging.py` — Per-service logger factory

### Data-gateway (Code Ready, Not Yet Deployed)
- `services/data-gateway/main.py` — Entry point for data ingestion service
- `yfinance_fetcher.py` — Async yfinance data fetcher
- `sensibull_fetcher.py` — Async Sensibull REST fetcher

### Configuration
- `configs/redis.conf` — Production Redis config (128MB, LRU, no persistence)
- `requirements.txt` — Added `redis==5.2.1`
- `.env.template` — Added `REDIS_URL`, removed deprecated flag

### Makefile (273 lines added)
- Redis targets: `redis-install`, `redis-start`, `redis-stop`, `redis-status`, `redis-config`
- Service targets: `run-notification`, `svc-notify-test`, `svc-notification-check`, `svc-dead-letter`
- Log targets: `logs-all`, `logs-all-follow`, `logs-svc`, `logs-svc-follow`, `logs-service`
- Server targets: `server-redis-*`, `server-notification-*`, `server-svcs-status`
- `run-dev` and `run-dev-positional` now auto-start/stop the notification service

### Documentation
- `plans/microservices_architecture.md` — Complete 2,229-line architecture design
- `docs/DESIGN.md` — Updated project structure, notification flow, per-service logging
- `README.md` — Updated architecture diagram, project structure, Makefile targets, Redis config

## Design Principles
- Redis is the only external dependency (50MB, 1 binary)
- Zero code changes to monolith analysers
- ID  identicalp to the existing behaviour when Redis is unavailable

Closes #12 PM stall — notification I/O is isolated